### PR TITLE
docs: update Run Interactive Apps

### DIFF
--- a/run-interactive-apps.qmd
+++ b/run-interactive-apps.qmd
@@ -26,7 +26,7 @@ Currently, Positron supports the following Python app frameworks:
     ![Positron App Launcher Play button](images/run-app-play-button.png)
 
 Then, Positron runs the app in a dedicated **Terminal** tab and opens the app URL in the **Viewer** pane.
-If your application does not automatically open in the Viewer, check that the setting [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) is enabled.
+If your application does not automatically open in the Viewer, check that the settings [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) and [`terminal.integrated.shellIntegration.enabled`](positron://settings/terminal.integrated.shellIntegration.enabled) are enabled.
 
 ![A Streamlit app in the Positron Viewer](images/run-app-streamlit.png)
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7547


We already have https://positron.posit.co/run-interactive-apps.html, but adding just a bit more for coverage pre-RC