### PR TITLE
API docs

### DIFF
--- a/extension-development.qmd
+++ b/extension-development.qmd
@@ -142,7 +142,7 @@ if (positron) {
 }
 ```
 
-Alternatively, if you just need to check but don't need the API you can use `inPositron()`
+Alternatively, if you just need to check but don't need the API you can use `inPositron()`:
 
 ```typescript
 import { inPositron } from '@posit-dev/positron';


### PR DESCRIPTION
This PR substantially increases the scope of the existing `extension-development` page and adds a new one called `api-advanced` that goes into further depth regarding using the Positron API in extensions. 

Docs now reference the new [`@posit-dev/positron` NPM package](https://www.npmjs.com/package/@posit-dev/positron) and a [template repo](https://github.com/posit-dev/positron-extension-template) for getting started with an extension.