### PR TITLE
Publish release notes to AWS S3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,6 @@ name: Quarto Publish
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write  # Required for OIDC
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4 


### PR DESCRIPTION
Address https://github.com/posit-dev/positron-builds/issues/389

This publishes the release notes to S3 so that Positron can display the markdown file in its release notes display.

* Added setting up AWS credentials
   * The credentials for S3 have been configured in AWS to allow `positron-website` actions to authenticate
   * The same still needs to be done for the CDN, which is why the cache invalidation is commented out (need to work with cloudops to update it)
* Extracts the release version from `download.qmd`
   * This is used to rename the release notes file and allows Positron to always fetch the release notes for its version

Credentials worked in this test run that only published the release notes:
https://github.com/posit-dev/positron-website/actions/runs/15854240779