### PR TITLE
Use release version in footer now

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -15,7 +15,7 @@ website:
   page-footer:
     left: |
       Copyright &copy; 2022-2025 Posit Software, PBC. All Rights Reserved.
-    center: "Positron Public Beta"
+    center: "Positron {{< env RELEASE_VERSION >}}"
     right:
       - text: "License"
         href: licensing.qmd


### PR DESCRIPTION
This PR removes the beta footer and uses whatever the current release version is.