### PR TITLE
Update page on license: add a title, add link to air

### DIFF
--- a/licensing.qmd
+++ b/licensing.qmd
@@ -1,3 +1,7 @@
+---
+title: "Licensing"
+---
+
 Positron is licensed under the [Elastic License 2.0](https://github.com/posit-dev/positron?tab=License-1-ov-file#readme), a source-available license. This license makes Positron available for free to everyone to use, build on, and extend for personal, academic, and commercial use. Its primary restriction is that you can't host Positron as a service to third parties without Posit's agreement. This restriction is necessary for us to build a sustainable business around Positron while also offering it free of charge to the community.
 
-Posit remains committed to both free and open-source software, and we're releasing several components of Positron under the more permissive MIT license. These components include Positron's high-performance [R kernel and Language Server Protocol implementation](https://github.com/posit-dev/ark).
+Posit remains committed to both free and open-source software, and we're releasing several components of Positron under the more permissive MIT license. These components include Positron's high-performance [R kernel and Language Server Protocol implementation](https://github.com/posit-dev/ark) and [R formatter](https://github.com/posit-dev/air).


### PR DESCRIPTION
I noticed that this page currently doesn't have a nice title, which looks bad in browsers: https://positron.posit.co/licensing.html

I also added a link to air.