### PR TITLE
patch - remove wistia cookie tracking

### DIFF
--- a/features.qmd
+++ b/features.qmd
@@ -75,7 +75,7 @@ Interested in Positron for your team? [Learn about enterprise solutions.](https:
 ::: {.hero-video}
 ```{=html}
 <script src="https://fast.wistia.com/player.js" async></script>
-<script src="https://fast.wistia.com/embed/shybc7tztp.js" async type="module" doNotTrack="true"></script>
+<script src="https://fast.wistia.com/embed/shybc7tztp.js" async type="module"></script>
 <style>
 wistia-player[media-id='shybc7tztp']:not(:defined) { 
   background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/shybc7tztp/swatch'); 
@@ -96,7 +96,7 @@ wistia-player[media-id='shybc7tztp']:not(:defined) {
 ::: {.hero-video}
 ```{=html}
 <script src="https://fast.wistia.com/player.js" async></script>
-<script src="https://fast.wistia.com/embed/zhzn80uv1u.js" async type="module" doNotTrack="true"></script>
+<script src="https://fast.wistia.com/embed/zhzn80uv1u.js" async type="module"></script>
 <style>
 wistia-player[media-id='zhzn80uv1u']:not(:defined) { 
   background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/zhzn80uv1u/swatch'); 
@@ -115,7 +115,7 @@ wistia-player[media-id='zhzn80uv1u']:not(:defined) {
 ## Develop with confidence
 ::: {.hero-video}
 ```{=html}
-<script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/818ycanm51.js" async type="module" doNotTrack="true"></script><style>wistia-player[media-id='818ycanm51']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/818ycanm51/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="818ycanm51" aspect="1.7777777777777777" autoplay="false" aria-label="Positron features demonstration video" doNotTrack="true"></wistia-player>
+<script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/818ycanm51.js" async type="module"></script><style>wistia-player[media-id='818ycanm51']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/818ycanm51/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="818ycanm51" aspect="1.7777777777777777" autoplay="false" aria-label="Positron features demonstration video" doNotTrack="true"></wistia-player>
 ```
 :::
 

--- a/index.qmd
+++ b/index.qmd
@@ -36,7 +36,7 @@ From [Posit PBC](https://posit.co/), the creators of RStudio
 <a href="features.qmd" class="btn btn-outline-primary">Explore Features</a>
 
 <div id="hero-video-container">
-  <script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/ncfm02eugr.js" async type="module" doNotTrack="true"></script><style>wistia-player[media-id='ncfm02eugr']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/ncfm02eugr/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="ncfm02eugr" aspect="1.7777777777777777" title="Positron Overview - the Data Science Code Editor for Python & R" doNotTrack="true"></wistia-player>
+  <script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/ncfm02eugr.js" async type="module"></script><style>wistia-player[media-id='ncfm02eugr']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/ncfm02eugr/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="ncfm02eugr" aspect="1.7777777777777777" title="Positron Overview - the Data Science Code Editor for Python & R" doNotTrack="true"></wistia-player>
 </div>
 
 Positron™ is licensed under the [Elastic License 2.0](https://github.com/posit-dev/positron?tab=License-1-ov-file#readme), a source-available license. [Read more](licensing.qmd) about what this license means and our decision to use it.


### PR DESCRIPTION
The current embedded wistia videos add cookies for tracking

Enabled do not track setting for all wistia videos 
https://docs.wistia.com/docs/embed-options-and-plugins#donottrack