### PR TITLE
Continue to render `astropy.png` to public site, since folks link to it

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,7 @@ project:
   type: posit-docs
   render:
     - "*.qmd"
+    - "images/astropy.png"
 
 execute:
   freeze: auto


### PR DESCRIPTION
We aren't using this image anywhere on the site anymore, but we can continue to make it available at <https://positron.posit.co/images/astropy.png>