### PR TITLE
Add text of license to website, for linkability

### DIFF
--- a/licensing.qmd
+++ b/licensing.qmd
@@ -19,7 +19,7 @@ SOFTWARE, PBC ("LICENSOR") AND YOU (INCLUDING YOUR COMPANY, IF APPLICABLE).
 YOUR ACCEPTANCE OF THIS LICENSE AGREEMENT IS REQUIRED AS A CONDITION TO
 PROCEEDING WITH YOUR DOWNLOAD OR USE OF THE SOFTWARE.
 
-
+<!-- vale Posit.Headings = NO -->
 ## Elastic License 2.0
 
 ### Acceptance
@@ -119,3 +119,4 @@ these terms.
 **use** means anything you do with the software requiring one of your licenses.
 
 **trademark** means trademarks, service marks, and similar rights.
+<!-- vale Posit.Headings = Yes -->


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron-builds/issues/540 by putting the text of the license here, so we can link to it.

I styled the HTML mostly the same as https://www.elastic.co/licensing/elastic-license, but am not strongly advocating for that if there are other considerations.