### PR TITLE
Add Supported by Posit badge and LinkedIn icon to navbar

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -71,6 +71,9 @@ website:
       - icon: github
         aria-label: 'Link to Positron Github Repository'
         href: https://github.com/posit-dev/positron
+      - icon: linkedin
+        aria-label: 'Link to Positron LinkedIn page'
+        href: https://www.linkedin.com/showcase/positron-ide/
       - icon: rss
         href: https://positron.posit.co/blog/index.xml
         aria-label: Positron Blog RSS
@@ -221,6 +224,22 @@ format:
     include-in-header:
       - text: |
           <script defer file-types="exe,dmg,deb,rpm" data-domain="positron.posit.co" src="https://plausible.io/js/script.file-downloads.js"></script>
+      - text: |
+          <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js"></script>
+      - text: |
+          <script>
+          document.addEventListener('DOMContentLoaded', function() {
+            var observer = new MutationObserver(function() {
+              var badge = document.getElementById('supported-by-posit');
+              if (badge) {
+                observer.disconnect();
+                var navCollapse = document.querySelector('.navbar-collapse');
+                if (navCollapse) navCollapse.appendChild(badge);
+              }
+            });
+            observer.observe(document.body, {childList: true, subtree: true});
+          });
+          </script>
       - "assets/_kapa-ai.html"
 
 show-videos: true

--- a/css/theme.scss
+++ b/css/theme.scss
@@ -82,6 +82,14 @@ nav .nav-item:not(.compact) {
   margin-bottom: -6px !important;
 }
 
+// Supported by Posit badge - show in mobile collapsed menu
+@media (max-width: 991.98px) {
+  #supported-by-posit {
+    display: flex !important;
+    margin: 10px 0 !important;
+  }
+}
+
 // Sidebar
 div.sidebar-item-container .active,
 div.sidebar-item-container .show > .nav-link,


### PR DESCRIPTION
## Summary
- Adds the "Supported by Posit" badge to the navbar via CDN script, with a custom script to move it into the collapsed mobile menu
- Adds LinkedIn icon in the navbar linking to the [Positron IDE showcase page](https://www.linkedin.com/showcase/positron-ide/)
- Adds CSS to ensure the badge is visible in the mobile hamburger menu
<img width="893" height="679" alt="Screenshot 2026-04-08 at 3 11 30 PM" src="https://github.com/user-attachments/assets/6d8538ff-d473-4939-bc5a-caa44d87a6a7" />
<img width="1505" height="359" alt="Screenshot 2026-04-08 at 3 11 19 PM" src="https://github.com/user-attachments/assets/7f14e548-b9c4-4503-b3ea-7d2dd0157378" />




## Test plan
- [X] Verify the "Supported by Posit" badge appears in the upper-right navbar on desktop
- [X] Verify the LinkedIn icon appears between GitHub and RSS icons and links correctly
- [X] Resize to mobile width and confirm the badge appears in the collapsed hamburger menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)