### PR TITLE
Apply doc-reviewer skill to new Python LSP section

### DIFF
--- a/guide-python.qmd
+++ b/guide-python.qmd
@@ -54,7 +54,7 @@ Positron provides three new, custom magics created specifically for working in P
 
 ## Code formatting
 
-Positron can format Python code with [Ruff](https://docs.astral.sh/ruff/), a Python linter and formatter. Ruff is included in Positron as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions) that is installed for you, including the bundled Ruff command line tool. Most Positron users do not need to do anything intentional to install Ruff or to keep it up-to-date.
+Positron can format Python code with [Ruff](https://docs.astral.sh/ruff/), a Python linter and formatter. Positron includes Ruff as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions) and installs it for you, including the bundled Ruff command line tool. Most Positron users do not need to do anything intentional to install Ruff or to keep it up-to-date.
 
 You can format your Python code with various explicit and implicit gestures. You can use the commands *Format Selection* or *Format Document* to format specific bits of code. You can even configure Positron to run Ruff automatically whenever you save a Python file. In the Settings UI, search for `@lang:python editor.formatOnSave` and enable the setting, either at the workspace (recommended) or user level. This will add the following to the appropriate `settings.json`:
 

--- a/guide-python.qmd
+++ b/guide-python.qmd
@@ -18,9 +18,9 @@ Positron provides setting defaults for working with Python for data science, but
 
 You can see _all_ the setting defaults that Positron provides with the command _Preferences: Open Default Settings (JSON)_.
 
-## Python Language Server
+## Python language server
 
-Positron's unique built-in language server uses your running Python session to provide runtime-aware completions and hover previews. Beyond what's in code, it knows your DataFrame column names, your dictionary keys, your environment variables, and more. As discussed in the [Settings section above](#settings), it also bundles [Pyrefly](https://pyrefly.org/) to handle the _static analysis_ side: type checking, go-to-definition, rename, and code actions. Both run concurrently, and Positron merges their results.
+The built-in language server in Positron uses your running Python session to provide runtime-aware completions and hover previews. Beyond what is in code, it knows your DataFrame column names, your dictionary keys, your environment variables, and more. As discussed in the [Settings section above](#settings), it also bundles [Pyrefly](https://pyrefly.org/) to handle the static analysis side: type checking, go-to-definition, rename, and code actions. Both run concurrently, and Positron merges their results.
 
 Positron also makes it straightforward to switch the static analysis language server:
 
@@ -40,7 +40,7 @@ If you want to permanently keep Pyrefly from auto-activating, you can use the [`
 }
 ```
 
-To read more about Python language servers, check out our [blog post](blog/posts/2026-03-31-python-type-checkers/index.qmd).
+To read more about Python language servers, see our [blog post on Python type checkers and language servers](blog/posts/2026-03-31-python-type-checkers/index.qmd).
 
 ## Magics
 


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron-website/pull/324

I think maybe that got merged without applying the style guide via the `doc-reviewer` Claude skill.