### PR TITLE
Document pixi support

### DIFF
--- a/_python-managers.qmd
+++ b/_python-managers.qmd
@@ -1,4 +1,4 @@
 * **venv**: Standard library virtual environments created with `python -m venv`
 * **uv**: Virtual environments and Python installations managed by `uv`
 * **pyenv**: Python installations managed by `pyenv`, including virtual environments
-* **conda**: Conda environments created with `conda create` or `mamba create`
+* **conda**: Conda environments created with `conda create` or `mamba create`, as well as pixi environments created with `pixi init`

--- a/r-installations.qmd
+++ b/r-installations.qmd
@@ -35,12 +35,14 @@ Positron consults various sources to build the list of available R interpreters:
 
 ## Customizing R discovery
 
-If you have an R installation that won't be discovered by the search strategy described above, two settings are available to instruct Positron to look in additional locations:
+If you have an R installation that won't be discovered by the search strategy described above, settings are available to instruct Positron to look in additional locations:
 
 * [`positron.r.customRootFolders`](positron://settings/positron.r.customRootFolders): Suitable for R root folders that contain 1 or more R installations.
   - Hypothetical example: `C:/nonstandardRLocation`
 * [`positron.r.customBinaries`](positron://settings/positron.r.customBinaries): Suitable for specific R executables.
   - Hypothetical example: `C:/nonstandardRLocation/R-4.4.1/bin/x64/R.exe`
+* [`positron.r.interpreters.condaDiscovery`](positron://settings/positron.r.interpreters.condaDiscovery): Enables discovery of R installations managed by conda (experimental).
+* [`positron.r.interpreters.pixiDiscovery`](positron://settings/positron.r.interpreters.pixiDiscovery): Enables discovery of R installations managed by pixi (experimental).
 
 You can navigate to these settings by running the _Preferences: Open Settings_ command from the Command Palette.
 Then select **Extensions** > **R** > **Advanced**.

--- a/r-installations.qmd
+++ b/r-installations.qmd
@@ -41,11 +41,11 @@ If you have an R installation that won't be discovered by the search strategy de
   - Hypothetical example: `C:/nonstandardRLocation`
 * [`positron.r.customBinaries`](positron://settings/positron.r.customBinaries): Suitable for specific R executables.
   - Hypothetical example: `C:/nonstandardRLocation/R-4.4.1/bin/x64/R.exe`
-* [`positron.r.interpreters.condaDiscovery`](positron://settings/positron.r.interpreters.condaDiscovery): Enables discovery of R installations managed by conda (experimental).
-* [`positron.r.interpreters.pixiDiscovery`](positron://settings/positron.r.interpreters.pixiDiscovery): Enables discovery of R installations managed by pixi (experimental).
+* [`positron.r.interpreters.condaDiscovery`](positron://settings/positron.r.interpreters.condaDiscovery): Enables discovery of R installations managed by conda. This support is experimental and not all Positron features may work as expected.
+* [`positron.r.interpreters.pixiDiscovery`](positron://settings/positron.r.interpreters.pixiDiscovery): Enables discovery of R installations managed by pixi. This support is also experimental.
 
 You can navigate to these settings by running the _Preferences: Open Settings_ command from the Command Palette.
-Then select **Extensions** > **R** > **Advanced**.
+Then select **Extensions > R > Advanced**.
 It's important to use absolute paths in these settings and not rely on shell features, such as parameter expansion (e.g., `${HOME}`).
 
 ## Unsupported R installations


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12249

I mentioned pixi in two places:

- in our list of supported Python managers, which gets re-used several places
- on the R installations page, under "Customizing R discovery"