### PR TITLE
Add new `workflow_call` trigger for GH action to release docs bundles

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -12,6 +12,13 @@ on:
         required: true
         type: string
         default: releases
+    secrets:
+      AWS_S3_RW_ROLE:
+        required: true
+      AWS_CDN_RW_ROLE:
+        required: true
+      AWS_CDN_DISTRIBUTION_ID:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -1,4 +1,17 @@
 on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+      overwrite:
+        required: false
+        type: boolean
+        default: false
+      release_channel:
+        required: true
+        type: string
+        default: releases
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron-builds/issues/908

We need to be able to call this workflow here over from the daily release workflow, to get the automated PRs for Workbench set up correctly.

Right now I have `secrets: inherit` to pass the calling workflow's secrets to the called workflow. We need `AWS_S3_RW_ROLE`, `AWS_CDN_RW_ROLE`, and `AWS_CDN_DISTRIBUTION_ID`. I think these are repo-level secrets scoped only to `positron-website`, which means this won't work right now.