### PR TITLE
Add workflow to update all-releases.json after docs are published

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -48,6 +48,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      release_version: ${{ steps.get-version.outputs.release_version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -135,3 +137,12 @@ jobs:
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} \
             --paths "/positron/${{ inputs.release_channel }}/docs/*"
+
+  update-all-releases:
+    needs: build-docs
+    if: ${{ inputs.release_channel == 'releases' }}
+    uses: ./.github/workflows/update-all-releases-json.yml
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.build-docs.outputs.release_version }}
+      release_channel: ${{ inputs.release_channel }}

--- a/.github/workflows/update-all-releases-json.yml
+++ b/.github/workflows/update-all-releases-json.yml
@@ -1,0 +1,103 @@
+name: Update all-releases.json
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag, e.g. '2026.04.0-269'"
+        required: true
+        type: string
+      release_channel:
+        description: "Release channel"
+        required: true
+        type: string
+        default: releases
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag, e.g. '2026.04.0-269'"
+        required: true
+        type: string
+      release_channel:
+        description: "Release channel"
+        required: false
+        type: string
+        default: releases
+
+jobs:
+  update-all-releases:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch releases.json, validate, and build all-releases.json
+        env:
+          BASE_URL: https://cdn.posit.co/positron/${{ inputs.release_channel }}
+          DOCS_URL: https://cdn.posit.co/positron/${{ inputs.release_channel }}/docs/positron-workbench-docs-${{ inputs.release_tag }}.zip
+        run: |
+          for arch_dir in x86_64 arm64; do
+            releases_url="${BASE_URL}/pwb/${arch_dir}/releases.json"
+
+            echo "Fetching ${releases_url}"
+            releases_json=$(curl -sf "${releases_url}")
+
+            actual_version=$(echo "${releases_json}" | jq -r '.version')
+            if [ "${actual_version}" != "${{ inputs.release_tag }}" ]; then
+              echo "Error: version mismatch for ${arch_dir}." \
+                "Expected '${{ inputs.release_tag }}', got '${actual_version}'"
+              exit 1
+            fi
+
+            pub_date=$(echo "${releases_json}" | jq -r '.pub_date')
+            url=$(echo "${releases_json}" | jq -r '.url')
+            sha256hash=$(echo "${releases_json}" | jq -r '.sha256hash')
+
+            python scripts/workbench-metadata/update-all-releases.py \
+              --version "${{ inputs.release_tag }}" \
+              --pub-date "${pub_date}" \
+              --url "${url}" \
+              --sha256hash "${sha256hash}" \
+              --docs-url "${DOCS_URL}" \
+              --existing-url "${BASE_URL}/pwb/${arch_dir}/all-releases.json" \
+              --output "pwb-${arch_dir}-all-releases.json"
+          done
+
+      - name: Configure AWS Credentials for S3
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_RW_ROLE }}
+          aws-region: us-east-1
+
+      - name: Upload all-releases.json files to S3
+        run: |
+          aws s3 cp pwb-x86_64-all-releases.json \
+            s3://posit-positron-downloads/positron/${{ inputs.release_channel }}/pwb/x86_64/all-releases.json \
+            --no-progress
+          aws s3 cp pwb-arm64-all-releases.json \
+            s3://posit-positron-downloads/positron/${{ inputs.release_channel }}/pwb/arm64/all-releases.json \
+            --no-progress
+
+      - name: Configure AWS Credentials for CloudFront
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CDN_RW_ROLE }}
+          aws-region: us-east-1
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} \
+            --paths \
+              "/positron/${{ inputs.release_channel }}/pwb/x86_64/all-releases.json" \
+              "/positron/${{ inputs.release_channel }}/pwb/arm64/all-releases.json"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /.luarc.json
 
 **/*.quarto_ipynb
+__pycache__/

--- a/scripts/workbench-metadata/update-all-releases.py
+++ b/scripts/workbench-metadata/update-all-releases.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Update Workbench all-releases.json with a new release entry."""
+
+import argparse
+import json
+from datetime import date
+import urllib.error
+import urllib.request
+
+EXPIRY_MONTHS = 18
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--pub-date', required=True)
+    parser.add_argument('--url', required=True)
+    parser.add_argument('--sha256hash', required=True)
+    parser.add_argument('--docs-url', required=True)
+    parser.add_argument('--existing-url', required=True, help='CDN URL of existing all-releases.json')
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--dry-run', action='store_true', help='Print output to stdout instead of writing file')
+    args = parser.parse_args()
+
+    # Download existing releases (or start fresh)
+    try:
+        with urllib.request.urlopen(args.existing_url) as response:
+            existing = json.loads(response.read().decode()).get('releases', [])
+        print(f"Downloaded {len(existing)} existing releases from {args.existing_url}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            existing = []
+            print(f"No existing releases found (starting fresh): {e}")
+        else:
+            raise
+
+    # Create new entry
+    new_entry = {
+        'version': args.version,
+        'pub_date': args.pub_date,
+        'url': args.url,
+        'sha256hash': args.sha256hash,
+        'docs_url': args.docs_url,
+    }
+
+    # Remove existing entry with same year and month only if new version has a newer patch
+    version_month = '.'.join(args.version.split('.')[:2])
+    new_patch = int(args.version.split('.')[2].split('-')[0])
+
+    existing_same_month = next(
+        (r for r in existing if '.'.join(r.get('version', '').split('.')[:2]) == version_month), None
+    )
+    if existing_same_month is not None:
+        try:
+            existing_patch = int(existing_same_month['version'].split('.')[2].split('-')[0])
+        except (IndexError, ValueError, KeyError):
+            existing_patch = -1
+        if new_patch < existing_patch:
+            print(f"Skipping: existing version {existing_same_month['version']} has a newer patch than {args.version}")
+            return
+
+    releases = [r for r in existing if '.'.join(r.get('version', '').split('.')[:2]) != version_month]
+    releases.append(new_entry)
+
+    # Filter: only keep releases within 18 months
+    total_months = date.today().year * 12 + date.today().month - EXPIRY_MONTHS
+    cutoff = date(total_months // 12, total_months % 12 or 12, 1)
+
+    def parse_version_date(version_str):
+        parts = version_str.split('.')
+        try:
+            return date(int(parts[0]), int(parts[1]), 1)
+        except (ValueError, IndexError, TypeError):
+            return date.max
+
+    filtered = [r for r in releases if parse_version_date(r.get('version', '')) >= cutoff]
+    removed_count = len(releases) - len(filtered)
+    if removed_count > 0:
+        print(f"Filtered out {removed_count} releases older than {EXPIRY_MONTHS} months")
+
+    # Sort by version descending
+    filtered.sort(key=lambda r: r.get('version', ''), reverse=True)
+
+    output_data = {'releases': filtered}
+
+    if args.dry_run:
+        print(f"\n--- DRY RUN: Would write {len(filtered)} releases to {args.output} ---")
+        print(json.dumps(output_data, indent=2))
+    else:
+        with open(args.output, 'w') as f:
+            json.dump(output_data, f, indent=2)
+        print(f"Wrote {len(filtered)} releases to {args.output}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Part 2 of posit-dev/positron-builds#934

Brings over the workflow to update all-releases.json and associated python script with a few changes:
- Workflow is now precedented by the release docs job 
- Include `docs_url` for each release entry (addressing posit-dev/positron#12197`)
- Updated deduplication logic to compare year and month rather than exact version so that only the latest patch is included for each version
- Removed fields that weren't being used: name, commit, and codeoss_verison