### PR TITLE
Actually checkout the specific repo here

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -53,6 +53,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: posit-dev/positron-website
+          ref: main
 
       - name: Get Release Version
         id: get-version


### PR DESCRIPTION
The new daily docs bundle in `posit-dev/positron-builds` called via `uses: posit-dev/positron-website/.github/workflows/release-docs-bundles.yml@main` did not work because the `Set up Quarto` step failed with a 404:

```
https://github.com/quarto-dev/quarto-cli/releases/download/v/quarto--linux-amd64.deb
```

Note the empty version between `v` and `/quarto--`. The `Get Quarto Version` step here reads `netlify.toml`:

```bash
QUARTO_VERSION=$(grep 'version = ' netlify.toml | sed '…')
```

but the step right before it, `actions/checkout@v4`, had no `repository:` argument. In a reusable workflow, that defaults to `github.repository`, which is the **caller's** repo (`positron-builds`), not the repo the workflow file lives in. So the workflow was checking out `positron-builds`, which has no `netlify.toml`, `grep` returned nothing, and the Quarto version was empty. The subsequent `quarto render` steps would have failed for the same reason since there were actually no docs sources on disk.

To fix, we need to pin the checkout to `posit-dev/positron-website@main` so this workflow always reads its own `netlify.toml` and docs sources regardless of which repo calls it.

No changes needed on the `positron-builds` side.
