### PR TITLE
add flag to skip writing release body during release workflow

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
         default: releases
-      set_release_body:
+      create_release:
         required: false
         type: boolean
         default: true
@@ -111,7 +111,7 @@ jobs:
           gh release delete ${{ steps.get-version.outputs.release_version }} --yes --cleanup-tag || true
 
       - name: Create Release
-        if: ${{ inputs.set_release_body != false }}
+        if: ${{ inputs.create_release }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get-version.outputs.release_version }}
@@ -122,13 +122,13 @@ jobs:
             positron-docs-${{ steps.get-version.outputs.release_version }}.zip
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
 
-      - name: Upload Release Assets
-        if: ${{ inputs.set_release_body == false }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.get-version.outputs.release_version }}
-          files: |
-            positron-docs-${{ steps.get-version.outputs.release_version }}.zip
+      - name: Upload assets to existing release
+        if: ${{ !inputs.create_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.get-version.outputs.release_version }} \
+            positron-docs-${{ steps.get-version.outputs.release_version }}.zip \
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
 
       - name: Configure AWS Credentials for S3

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
         default: releases
+      set_release_body:
+        required: false
+        type: boolean
+        default: true
     secrets:
       AWS_S3_RW_ROLE:
         required: true
@@ -107,12 +111,22 @@ jobs:
           gh release delete ${{ steps.get-version.outputs.release_version }} --yes --cleanup-tag || true
 
       - name: Create Release
+        if: ${{ inputs.set_release_body != false }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get-version.outputs.release_version }}
           name: ${{ steps.get-version.outputs.release_version }}
           body: |
             Documentation for https://github.com/posit-dev/positron/releases/tag/${{ steps.get-version.outputs.release_version }}
+          files: |
+            positron-docs-${{ steps.get-version.outputs.release_version }}.zip
+            positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
+
+      - name: Upload Release Assets
+        if: ${{ inputs.set_release_body == false }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get-version.outputs.release_version }}
           files: |
             positron-docs-${{ steps.get-version.outputs.release_version }}.zip
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron-builds/issues/949

When this workflow is called from positron-builds (via `workflow_call`), the release already exists with a release body. Previously, `softprops/action-gh-release@v2` would overwrite that body with a generic "Documentation for <url>" message, which is coming from this repo's workflow.

This PR adds a `create_release` input (defaults to `true` so the workflows in this repo continue to behave as before) that controls whether the workflow creates a new release or just uploads assets to an existing one:

- `create_release: true` (default, when a release is created manually from this repo): Creates the release with body + files using softprops, same as before.
- `create_release: false` (positron-builds caller): Uploads zip files to the existing release using `gh release upload`, and does not modify the release body or name.

This does rely on the fact that the release already exists when `create_release: false` is used, but that should be the case in the positron-builds workflows.

We'll need to confirm this is working by reviewing the next positron-builds PR that calls this workflow with `create_release: false` and verifying that the release body is not overwritten.