### PR TITLE
try another linter to reduce flaky lint CI failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: Check URLs
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
-          args: "--no-progress './**/*.qmd' './_redirects'"
+          args: "--no-progress --verbose './**/*.qmd' './_redirects'"
           fail: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ on: pull_request
 
 name: Lint
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -9,16 +12,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Check URLs in Quarto files
-        uses: urlstechie/urlchecker-action@b643b43e2ac605e1475331c7b67247d242b7dce4  # v0.0.34
+      - name: Check URLs
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
-          file_types: .qmd
-          exclude_patterns: https://cdn.posit.co/positron/prereleases/,https://positron.posit.co/images/,https://github.com/posit-dev/positron/issues
-          retry_count: 3
-
-      - name: Check URLs in _redirects
-        uses: urlstechie/urlchecker-action@b643b43e2ac605e1475331c7b67247d242b7dce4  # v0.0.34
-        with:
-          include_files: _redirects
-          file_types: _redirects
-          retry_count: 3
+          args: "--no-progress './**/*.qmd' './_redirects'"
+          fail: true

--- a/lychee.toml
+++ b/lychee.toml
@@ -6,9 +6,10 @@ exclude = [
   "https://cdn.posit.co/positron/prereleases/",
   "https://positron.posit.co/images/",
   "https://github.com/posit-dev/positron/issues",
-  "positron://settings/"
+  "positron://settings/",
+  "https://forms.gle/DRCf8wgbaafz5fcG8" # testimonial Google Form (requires login)
 ]
 
-# 403 (Forbidden) and 429 (Too Many Requests) are returned by sites like
-# Microsoft and Snowflake that block automated requests, not broken links.
-accept = [200, 429, 403]
+# 403 (Forbidden) and 429 (Too Many Requests) are returned by sites that
+# block automated requests, not broken links.
+accept = [200, 403, 429]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,14 @@
+max_concurrency = 4
+max_retries = 5
+retry_wait_time = 10
+
+exclude = [
+  "https://cdn.posit.co/positron/prereleases/",
+  "https://positron.posit.co/images/",
+  "https://github.com/posit-dev/positron/issues",
+  "positron://settings/"
+]
+
+# 403 (Forbidden) and 429 (Too Many Requests) are returned by sites like
+# Microsoft and Snowflake that block automated requests, not broken links.
+accept = [200, 429, 403]


### PR DESCRIPTION
the lint job fails a lot 😢, and results in having to check the lint job output, only to see that the failed URLs are actually fine, but we got blocked or rate limited in some way during the url checking.

Failure rate of 69%:
<img width="904" height="61" alt="image" src="https://github.com/user-attachments/assets/e0f4312c-f12e-46dd-b45c-816cfcbf014e" />

---

This PR switches us to lychee for the lint checker (https://github.com/lycheeverse/lychee-action), which has more customizability and seems to avoid the bot checking / rate limiting by running concurrent link checking requests and using exponential backoff for retries.

We also get a bit more info about the state of our URLs. In particular, there are quite a few redirects that we could consider updating our urls to the new url for. The github action summary shows more detail: https://github.com/posit-dev/positron-website/actions/runs/24674497576/attempts/1#summary-72154467820

The lint job still takes about the same amount of time (~1.5 mins), maybe slightly less than before on average, since the lint job sometimes took > 2 or 3 minutes, whereas this one currently is pretty consistently taking ~1.5 mins.

The goal here is not necessarily a lower failure rate, but definitely a lower failure rate for URLs that are actually working. In particular, we tend to see Microsoft and Snowflake urls fail in the lint job even though the URLs are still live, so these should stop failing!