### PR TITLE
set repo for uploading assets to release

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -129,7 +129,6 @@ jobs:
         run: |
           gh release upload ${{ steps.get-version.outputs.release_version }} \
             --repo ${{ github.repository }} \
-            --clobber \
             positron-docs-${{ steps.get-version.outputs.release_version }}.zip \
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
 

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -128,6 +128,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ steps.get-version.outputs.release_version }} \
+            --repo ${{ github.repository }} \
+            --clobber \
             positron-docs-${{ steps.get-version.outputs.release_version }}.zip \
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
 


### PR DESCRIPTION
- a follow-up to https://github.com/posit-dev/positron-website/pull/337 to address https://github.com/posit-dev/positron-builds/issues/949
- fix `gh release upload` targeting the wrong repo when called via `workflow_call` from `positron-builds`, resulting in the release tag not being found, and the assets not getting uploaded

Passing `--repo` should ensure that the repo is the one from which the workflow is run (builds repo), rather than the repo where the workflow lives (this website repo).