### PR TITLE
Add education FAQ page

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -47,11 +47,7 @@ website:
       - text: "Help"
         href: troubleshooting.qmd
       - text: "About"
-        menu:
-          - text: "About Positron"
-            href: about.qmd
-          - text: "Education"
-            href: education.qmd
+        href: about.qmd
       - text: "Blog"
         href: blog/index.qmd
       - text: "Resources"

--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -47,7 +47,11 @@ website:
       - text: "Help"
         href: troubleshooting.qmd
       - text: "About"
-        href: about.qmd
+        menu:
+          - text: "About Positron"
+            href: about.qmd
+          - text: "Education"
+            href: education.qmd
       - text: "Blog"
         href: blog/index.qmd
       - text: "Resources"
@@ -205,6 +209,7 @@ website:
       contents:
         - about.qmd
         - release-notes.qmd
+        - education.qmd
         - privacy.qmd
         - licensing.qmd
     

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -9,6 +9,7 @@ project:
     - "!remote-ssh.qmd"
     - "!dev-containers.qmd"
     - "!add-to-path.qmd"
+    - "!education.qmd"
     - "!blog/**"
   resources:
     - _redirects

--- a/education.qmd
+++ b/education.qmd
@@ -2,7 +2,7 @@
 title: "Positron for Education"
 description: "Bring Positron to your classroom with a free teaching license."
 ---
-## Why use Positron in the classroom?
+## A true multi-language IDE for data science for all
 
 With Positron, students get access to a robust data science IDE with features designed to support learning and productivity, including:
 
@@ -16,11 +16,10 @@ Explore the full list of [Positron features](features.qmd).
 
 ## How can I use Positron in an educational setting?
 
-* Under the [Positron Elastic license](licensing.qmd), individuals may install and use Positron for any purpose.
-* Qualified academic institutions can host Positron as a service, via Positron Server, for their enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in the Positron [Academic License Rider](licensing.qmd#positron-education-license-rider).
-* Positron Server is available for JupyterHub environments. See the [jupyter-positron-server](https://posit-dev.github.io/jupyter-positron-server/) Python package documentation for more information about setup and usage.
-* Hosting of Positron for teaching purposes requires a free license key. Please reach out to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) and indicate your interest in Positron if you have further questions.
-* Lastly, Posit provides free teaching licenses of Posit Workbench, which includes Positron Pro and RStudio for browser-based access by multiple users. Visit [Workbench for Education](https://posit.co/pricing/academic#we-help-educators) to learn more.
+* Under the [Positron Elastic license](licensing.qmd), individuals may install and use Positron Desktop for any purpose.
+* Qualified academic institutions can host Positron as a service in the following ways. All of them require an [Academic License Rider](licensing.qmd#positron-education-license-rider).
+    * [Positron Server for Jupyter](https://posit-dev.github.io/jupyter-positron-server/)
+    * [Posit Workbench for Education](https://posit.co/pricing/academic#we-help-educators)
 
 ::: {.callout-note}
 ## We are here to help
@@ -68,7 +67,7 @@ The license lasts for 12 months from the desired start date you indicate when ap
 
 #### Can I disable specific extensions for all students?
 
-Settings can be configured by an admin by using the machine level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``. You can use the [`extensions.allowed` setting](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions) to approve or deny extensions for all users on your JupyterHub.
+An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``. You can use the [`extensions.allowed` setting](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions) to approve or deny extensions for all users on your JupyterHub.
 
 #### How do I upgrade Positron Server to the latest version?
 
@@ -76,7 +75,7 @@ Install the latest version of Positron to the same location.
 
 #### Can I pre-configure a default environment (specific packages, files, settings) so all students start from the same place?
 
-Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. Settings can be configured by an admin at machine level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``.
+Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``.
 
 #### Can I use Positron Server alongside Jupyter Notebooks at the same time?
 

--- a/education.qmd
+++ b/education.qmd
@@ -25,7 +25,7 @@ Explore the full list of [Positron features](features.qmd).
 ::: {.callout-tip}
 ## We're here to help
 
-[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education){.btn .btn-primary}
+[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education)
 
 Reach out via a discussion in our [Positron GitHub repository](https://github.com/posit-dev/positron/discussions)
 :::
@@ -65,10 +65,6 @@ No, the teaching license is only for instructional use. If you're interested in 
 #### Does the license expire at the end of the semester?
 
 The license lasts for 12 months from the desired start date you indicate when applying. Please note, we process licenses up to a maximum of two months prior to the start of a semester.
-
-#### Can students use Positron on their own machines?
-
-Yes, under the [Elastic License](licensing.qmd), any individual can download and use Positron for free, no institutional license required. Visit the [install page](install.qmd) to get started.
 
 #### Can I disable specific extensions for all students?
 

--- a/education.qmd
+++ b/education.qmd
@@ -2,13 +2,13 @@
 title: "Positron for Education"
 description: "Bring Positron to your classroom with a free teaching license."
 ---
-## Why Use Positron in the Classroom?
+## Why use Positron in the classroom?
 
 With Positron, students get access to a robust data science IDE with features designed to support learning and productivity, including:
 
 - Rich Python and R support
-- A built-in data viewer and variables explorer
-- An integrated help pane, debugger, and version control
+- A built-in Data Explorer and Variables pane
+- An integrated Help pane, debugger, and version control
 - A professional IDE tailored for data science
 - Optional AI assistance for pair programming and debugging
 
@@ -16,29 +16,29 @@ Explore the full list of [Positron features](features.qmd).
 
 ## How can I use Positron in an educational setting?
 
-* Under [Positron’s Elastic license](licensing.qmd), individual students are free to install and use the software for any purpose.
-* Qualified academic institutions may host Positron as a service for their currently enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in Positron’s [Academic License Rider](licensing.qmd#positron-education-license-rider).
+* Under the [Positron Elastic license](licensing.qmd), individual students are free to install and use the software for any purpose.
+* Qualified academic institutions can host Positron as a service, via Positron Server, for their enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in the Positron [Academic License Rider](licensing.qmd#positron-education-license-rider).
 * Positron Server is available for JupyterHub environments. See the [jupyter-positron-server](https://posit-dev.github.io/jupyter-positron-server/) Python package documentation for more information about setup and usage.
 * Hosting of Positron for teaching purposes requires a free license key. Please reach out to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) and indicate your interest in Positron if you have further questions.
-* Lastly, Posit provides free teaching licenses of Posit Workbench, which includes Positron Pro and RStudio for browser-based access by multiple users. Visit [Posit Workbench for Education](https://posit.co/pricing/academic#we-help-educators) to learn more.
+* Lastly, Posit provides free teaching licenses of Posit Workbench, which includes Positron Pro and RStudio for browser-based access by multiple users. Visit [Workbench for Education](https://posit.co/pricing/academic#we-help-educators) to learn more.
 
-::: {.callout-tip}
-## We're here to help
+::: {.callout-note}
+## We are here to help
 
-[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education)
+[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education).
 
-Reach out via a discussion in our [Positron GitHub repository](https://github.com/posit-dev/positron/discussions)
+Reach out via a discussion in our [GitHub repository](https://github.com/posit-dev/positron/discussions).
 :::
 
-## Eligibility for Teaching Licenses
+## Eligibility for teaching licenses
 
-Academic institutions can use Positron Server or Positron on Posit Workbench with a free teaching license. Full eligibility details are in Positron's [Academic License Rider](licensing.qmd#positron-education-license-rider).
+Academic institutions can use Positron Server or Positron on Workbench with a free teaching license. Full eligibility details are in the Positron [Academic License Rider](licensing.qmd#positron-education-license-rider).
 
-## Applying for a Teaching License
+## Applying for a teaching license
 
 1. **Check eligibility.** Review the [Positron Education License Rider](licensing.qmd#positron-education-license-rider) to confirm qualification for a teaching license.
 
-2. **Request a license.** Email [academic-licenses@posit.co](mailto:academic-licenses@posit.co) to get a free teaching license key.
+2. **Request a license.** Send an email to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) to get a free teaching license key.
 
 3. **Install instructions.** Based on the distribution method, follow the instructions below to get Positron up and running.
 
@@ -48,19 +48,19 @@ Academic institutions can use Positron Server or Positron on Posit Workbench wit
 2. Watch the [installation walkthrough](https://www.loom.com/share/9a8c760a4d4e45b2ac78d62ba3e1d0b3) for a step-by-step guide.
 
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 #### How much does a teaching license cost?
 
 Teaching licenses are free for qualified academic institutions.
 
-#### Does a teaching license cover both Positron Server and Positron on Posit Workbench?
+#### Does a teaching license cover both Positron Server and Positron on Workbench?
 
-Yes, with a teaching license you can choose multiple distribution options, including Positron Server and Positron on Posit Workbench.
+Yes, with a teaching license you can choose multiple distribution options, including Positron Server and Positron on Workbench.
 
 #### Can I use a teaching license for research purposes?
 
-No, the teaching license is only for instructional use. If you're interested in using Positron for research, you can use Positron Desktop or purchase a discounted research license. [Learn more about research licenses](https://posit.co/pricing/academic#we-help-educators).
+No, the teaching license is only for instructional use. If you are interested in using Positron for research, you can use Positron Desktop or purchase a discounted research license. [Learn more about research licenses](https://posit.co/pricing/academic#we-help-educators).
 
 #### Does the license expire at the end of the semester?
 
@@ -68,7 +68,7 @@ The license lasts for 12 months from the desired start date you indicate when ap
 
 #### Can I disable specific extensions for all students?
 
-Settings can be configured by an admin at the ``/home/jupyter-admin/.positron-server/data/Machine/settings.json`` file. You can use the extensions.allowed setting, read more [here](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions)
+Settings can be configured by an admin by using the machine level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``. You can use the [`extensions.allowed` setting](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions) to approve or deny extensions for all users on your JupyterHub.
 
 #### How do I upgrade Positron Server to the latest version?
 
@@ -76,7 +76,7 @@ Install the latest version of Positron to the same location.
 
 #### Can I pre-configure a default environment (specific packages, files, settings) so all students start from the same place?
 
-Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. Settings can be configured by an admin at the ``/home/jupyter-admin/.positron-server/data/Machine/settings.json`` file.
+Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. Settings can be configured by an admin at machine level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``.
 
 #### Can I use Positron Server alongside Jupyter Notebooks at the same time?
 

--- a/education.qmd
+++ b/education.qmd
@@ -24,9 +24,7 @@ Explore the full list of [Positron features](features.qmd).
 ::: {.callout-note}
 ## We are here to help
 
-[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education).
-
-Reach out via a discussion in our [GitHub repository](https://github.com/posit-dev/positron/discussions).
+[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education) or reach out via a discussion in our [GitHub repository](https://github.com/posit-dev/positron/discussions).
 :::
 
 ## Eligibility for teaching licenses

--- a/education.qmd
+++ b/education.qmd
@@ -7,8 +7,8 @@ description: "Bring Positron to your classroom with a free teaching license."
 With Positron, students get access to a robust data science IDE with features designed to support learning and productivity, including:
 
 - Rich Python and R support
-- A built-in Data Explorer and Variables pane
-- An integrated Help pane, debugger, and version control
+- A built-in **Data Explorer** and **Variables** pane
+- An integrated **Help** pane, debugger, and version control
 - A professional IDE tailored for data science
 - Optional AI assistance for pair programming and debugging
 

--- a/education.qmd
+++ b/education.qmd
@@ -57,11 +57,11 @@ No, the teaching license is only for instructional use. If you are interested in
 
 #### Does the license expire at the end of the semester?
 
-The license lasts for 12 months from the desired start date you indicate when applying. Please note, we process licenses up to a maximum of two months prior to the start of a semester.
+The license lasts for 12 months from the desired start date you indicate when applying. Please note, we only process licenses within two months before the start of a semester.
 
-#### Can I disable specific extensions for all students?
+#### Can I disable specific extensions for all students on JupyterHub?
 
-An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``. You can use the [`extensions.allowed` setting](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions) to approve or deny extensions for all users on your JupyterHub.
+An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``. You can use the [`extensions.allowed` setting](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions) to approve or deny extensions for all users on your JupyterHub server.
 
 #### How do I upgrade Positron Server to the latest version?
 
@@ -69,7 +69,7 @@ Install the latest version of Positron to the same location.
 
 #### Can I pre-configure a default environment (specific packages, files, settings) so all students start from the same place?
 
-Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``.
+Positron can locate Python environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. An admin can configure settings in the machine-level settings file, available at a path like ``/home/jupyter-admin/.positron-server/data/Machine/settings.json``.
 
 #### Can I use Positron Server alongside Jupyter Notebooks at the same time?
 

--- a/education.qmd
+++ b/education.qmd
@@ -1,0 +1,87 @@
+---
+title: "Positron for Education"
+description: "Bring Positron to your classroom with a free teaching license."
+---
+## Why Use Positron in the Classroom?
+
+With Positron, students get access to a robust data science IDE with features designed to support learning and productivity, including:
+
+- Rich Python and R support
+- A built-in data viewer and variables explorer
+- An integrated help pane, debugger, and version control
+- A professional IDE tailored for data science
+- Optional AI assistance for pair programming and debugging
+
+Explore the full list of [Positron features](features.qmd).
+
+## How can I use Positron in an educational setting?
+
+* Under [Positron’s Elastic license](licensing.qmd), individual students are free to install and use the software for any purpose.
+* Qualified academic institutions may host Positron as a service for their currently enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in Positron’s [Academic License Rider](licensing.qmd#positron-education-license-rider).
+* Positron Server is available for JupyterHub environments. See the [jupyter-positron-server](https://posit-dev.github.io/jupyter-positron-server/) Python package documentation for more information about setup and usage.
+* Hosting of Positron for teaching purposes requires a free license key. Please reach out to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) and indicate your interest in Positron if you have further questions.
+* Lastly, Posit provides free teaching licenses of Posit Workbench, which includes Positron Pro and RStudio for browser-based access by multiple users. Visit [Posit Workbench for Education](https://posit.co/pricing/academic#we-help-educators) to learn more.
+
+::: {.callout-tip}
+## We're here to help
+
+[Book a call with us](https://scheduler.zoom.us/cindy-tong/positron-education){.btn .btn-primary}
+
+Reach out via a discussion in our [Positron GitHub repository](https://github.com/posit-dev/positron/discussions)
+:::
+
+## Eligibility for Teaching Licenses
+
+Academic institutions can use Positron Server or Positron on Posit Workbench with a free teaching license. Full eligibility details are in Positron's [Academic License Rider](licensing.qmd#positron-education-license-rider).
+
+## Applying for a Teaching License
+
+1. **Check eligibility.** Review the [Positron Education License Rider](licensing.qmd#positron-education-license-rider) to confirm qualification for a teaching license.
+
+2. **Request a license.** Email [academic-licenses@posit.co](mailto:academic-licenses@posit.co) to get a free teaching license key.
+
+3. **Install instructions.** Based on the distribution method, follow the instructions below to get Positron up and running.
+
+## Installing Positron Server
+1. Follow the [`jupyter-positron-server` documentation](https://posit-dev.github.io/jupyter-positron-server/) to complete setup.
+
+2. Watch the [installation walkthrough](https://www.loom.com/share/9a8c760a4d4e45b2ac78d62ba3e1d0b3) for a step-by-step guide.
+
+
+## Frequently Asked Questions
+
+#### How much does a teaching license cost?
+
+Teaching licenses are free for qualified academic institutions.
+
+#### Does a teaching license cover both Positron Server and Positron on Posit Workbench?
+
+Yes, with a teaching license you can choose multiple distribution options, including Positron Server and Positron on Posit Workbench.
+
+#### Can I use a teaching license for research purposes?
+
+No, the teaching license is only for instructional use. If you're interested in using Positron for research, you can use Positron Desktop or purchase a discounted research license. [Learn more about research licenses](https://posit.co/pricing/academic#we-help-educators).
+
+#### Does the license expire at the end of the semester?
+
+The license lasts for 12 months from the desired start date you indicate when applying. Please note, we process licenses up to a maximum of two months prior to the start of a semester.
+
+#### Can students use Positron on their own machines?
+
+Yes, under the [Elastic License](licensing.qmd), any individual can download and use Positron for free, no institutional license required. Visit the [install page](install.qmd) to get started.
+
+#### Can I disable specific extensions for all students?
+
+Settings can be configured by an admin at the ``/home/jupyter-admin/.positron-server/data/Machine/settings.json`` file. You can use the extensions.allowed setting, read more [here](https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions)
+
+#### How do I upgrade Positron Server to the latest version?
+
+Install the latest version of Positron to the same location.
+
+#### Can I pre-configure a default environment (specific packages, files, settings) so all students start from the same place?
+
+Positron can locate conda environments as well as any files on a user’s JupyterHub instance, so packages and files in shared locations are automatically available. Settings can be configured by an admin at the ``/home/jupyter-admin/.positron-server/data/Machine/settings.json`` file.
+
+#### Can I use Positron Server alongside Jupyter Notebooks at the same time?
+
+Yes, Positron has a native Jupyter editor your students can work with. You can also have students open two tabs, one with Positron and another with JupyterLab.

--- a/education.qmd
+++ b/education.qmd
@@ -39,10 +39,6 @@ Academic institutions can use Positron Server or Positron on Workbench with a fr
 
 3. **Install instructions.** Based on the distribution method, follow the instructions below to get Positron up and running.
 
-## Installing Positron Server
-1. Follow the [`jupyter-positron-server` documentation](https://posit-dev.github.io/jupyter-positron-server/) to complete setup.
-
-2. Watch the [installation walkthrough](https://www.loom.com/share/9a8c760a4d4e45b2ac78d62ba3e1d0b3) for a step-by-step guide.
 
 
 ## Frequently asked questions

--- a/education.qmd
+++ b/education.qmd
@@ -16,7 +16,7 @@ Explore the full list of [Positron features](features.qmd).
 
 ## How can I use Positron in an educational setting?
 
-* Under the [Positron Elastic license](licensing.qmd), individual students are free to install and use the software for any purpose.
+* Under the [Positron Elastic license](licensing.qmd), individuals may install and use Positron for any purpose.
 * Qualified academic institutions can host Positron as a service, via Positron Server, for their enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in the Positron [Academic License Rider](licensing.qmd#positron-education-license-rider).
 * Positron Server is available for JupyterHub environments. See the [jupyter-positron-server](https://posit-dev.github.io/jupyter-positron-server/) Python package documentation for more information about setup and usage.
 * Hosting of Positron for teaching purposes requires a free license key. Please reach out to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) and indicate your interest in Positron if you have further questions.

--- a/education.qmd
+++ b/education.qmd
@@ -17,7 +17,7 @@ Explore the full list of [Positron features](features.qmd).
 ## How can I use Positron in an educational setting?
 
 * Under the [Positron Elastic license](licensing.qmd), individuals may install and use Positron Desktop for any purpose.
-* Qualified academic institutions can host Positron as a service in the following ways. All of them require an [Academic License Rider](licensing.qmd#positron-education-license-rider).
+* Qualified academic institutions can host Positron as a service in the following ways. All of them require a [license](licensing.qmd#positron-education-license-rider).
     * [Positron Server for Jupyter](https://posit-dev.github.io/jupyter-positron-server/)
     * [Posit Workbench for Education](https://posit.co/pricing/academic#we-help-educators)
 

--- a/education.qmd
+++ b/education.qmd
@@ -37,7 +37,9 @@ Academic institutions can use Positron Server or Positron on Workbench with a fr
 
 2. **Request a license.** Send an email to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) to get a free teaching license key.
 
-3. **Install instructions.** Based on the distribution method, follow the instructions below to get Positron up and running.
+3. **Install instructions.** Follow the instructions for your installation method to get Positron up and running. For example, for installing Positron on JupyterHub:
+  - See the [`jupyter-positron-server` documentation](https://posit-dev.github.io/jupyter-positron-server/) to complete setup.
+  - Watch the [installation walkthrough](https://www.loom.com/share/9a8c760a4d4e45b2ac78d62ba3e1d0b3) for a step-by-step guide.
 
 
 

--- a/education.qmd
+++ b/education.qmd
@@ -6,10 +6,10 @@ description: "Bring Positron to your classroom with a free teaching license."
 
 With Positron, students get access to a robust data science IDE with features designed to support learning and productivity, including:
 
+- A professional IDE tailored for data science
 - Rich Python and R support
 - A built-in **Data Explorer** and **Variables** pane
 - An integrated **Help** pane, debugger, and version control
-- A professional IDE tailored for data science
 - Optional AI assistance for pair programming and debugging
 
 Explore the full list of [Positron features](features.qmd).

--- a/faqs.qmd
+++ b/faqs.qmd
@@ -41,15 +41,13 @@ description: "Get answers to common questions about Positron: supported language
   * RStudio has deeper support for Sweave and R Markdown compared to our targeted focus on Quarto in Positron, although Positron does support rendering R Markdown documents as well.    
   * Positron does not have inline output for source `.qmd` or `.Rmd` documents, and Quarto or R Markdown documents will make use of the **Console** and **Plots** pane for execution/output. However, we are actively enhancing our Positron-native notebook UI that will provide inline outputs for Python or R sessions. Separately, we are also actively working on improving Quarto's Visual Editor to improve the authoring experience for Quarto. 
   * RStudio is extensible only via RStudio add-ins, and while Positron supports some of the same, existing RStudio add-ins, not all are supported. Rather than doubling down on the more limited RStudio add-in capabilities for novel integrations, we suggest exploring [extension development and our Positron API endpoints](extension-development.qmd).    
-  * We do _not_ plan to have a `.Rproj` equivalent for Positron (e.g., a `.positronproj`), but rather Positron can open and treat any folder as a "project" or workspace. We still suggest project-oriented workflows, and for more context, please see: [Migrating from RStudio: The Rproj File](migrate-rstudio-rproj.qmd).    
+  * We do _not_ plan to have a `.Rproj` equivalent for Positron (e.g., a `.positronproj`), but rather Positron can open and treat any folder as a "project" or workspace. We still suggest project-oriented workflows, and for more context, please see: [Migrating from RStudio: The Rproj File](migrate-rstudio-rproj.qmd).
 
 ::: {.content-visible unless-profile="workbench"}
 ### How can I use Positron in an educational setting?
 
-* Under [Positron's Elastic license](https://positron.posit.co/licensing.html), individual students are free to install and use the software for any purpose.  
-* Qualified academic institutions may host Positron as a service for their currently enrolled students solely for educational purposes in connection with their coursework via a free teaching license. Eligibility conditions are outlined in Positron's [Academic Licenser Rider](licensing.qmd#positron-education-license-rider)
-* Positron Server is available for JupyterHub environments. See the [`jupyter-positron-server` Python package documentation](https://posit-dev.github.io/jupyter-positron-server/) for more information about setup and usage.
-* Hosting of Positron for teaching purposes requires a free license key. Please reach out to [academic-licenses@posit.co](mailto:academic-licenses@posit.co) and indicate your interest in Positron if you have further questions.  
-* Lastly, Posit provides [free teaching licenses of Posit Workbench](https://posit.co/pricing/academic/), which includes Positron Pro for browser-based access by multiple users. 
+* Individual students can freely [download and use Positron](install.qmd) under the [Elastic License](licensing.qmd).
+* Academic institutions can host Positron for enrolled students via JupyterHub with a free teaching license.
+* Visit [Positron for Education](education.qmd) for full details on eligibility, setup, and how to request a license.
 
 :::

--- a/faqs.qmd
+++ b/faqs.qmd
@@ -42,12 +42,3 @@ description: "Get answers to common questions about Positron: supported language
   * Positron does not have inline output for source `.qmd` or `.Rmd` documents, and Quarto or R Markdown documents will make use of the **Console** and **Plots** pane for execution/output. However, we are actively enhancing our Positron-native notebook UI that will provide inline outputs for Python or R sessions. Separately, we are also actively working on improving Quarto's Visual Editor to improve the authoring experience for Quarto. 
   * RStudio is extensible only via RStudio add-ins, and while Positron supports some of the same, existing RStudio add-ins, not all are supported. Rather than doubling down on the more limited RStudio add-in capabilities for novel integrations, we suggest exploring [extension development and our Positron API endpoints](extension-development.qmd).    
   * We do _not_ plan to have a `.Rproj` equivalent for Positron (e.g., a `.positronproj`), but rather Positron can open and treat any folder as a "project" or workspace. We still suggest project-oriented workflows, and for more context, please see: [Migrating from RStudio: The Rproj File](migrate-rstudio-rproj.qmd).
-
-::: {.content-visible unless-profile="workbench"}
-### How can I use Positron in an educational setting?
-
-* Individual students can freely [download and use Positron](install.qmd) under the [Elastic License](licensing.qmd).
-* Academic institutions can host Positron for enrolled students via JupyterHub with a free teaching license.
-* Visit [Positron for Education](education.qmd) for full details on eligibility, setup, and how to request a license.
-
-:::


### PR DESCRIPTION
Add a dedicated Education page (`education.qmd`) with information about using Positron in educational settings, including license eligibility, application procedures, installation instructions, and an FAQ.

## Changes
- New `education.qmd` page with sections on features, licensing, eligibility, setup, and FAQ
- Added to Positron nav config; excluded from Workbench profile
- Removed education FAQ entries from `faqs.qmd` (moved to dedicated page)
- Applied PR review feedback: updated heading, clarified Positron Desktop licensing, condensed hosting options, reworded license processing sentence, added JupyterHub context to FAQ heading/answer
- Applied style guide fixes: removed time-anchored language, fixed passive voice, added hyphens to compound modifiers, introduced long-form product name for Posit Workbench, changed conda to Python environments

<img width="1102" height="516" alt="Screenshot 2026-04-23 at 4 44 51 PM" src="https://github.com/user-attachments/assets/47750378-9923-4eeb-9400-922031641690" />