### PR TITLE
Update Positron Notebook Editor docs: alpha to beta

### DIFF
--- a/_notebook-customization.qmd
+++ b/_notebook-customization.qmd
@@ -1,3 +1,1 @@
-### Customization
-
-To set the default working directory for a notebook, use the [`notebook.workingDirectory`](positron://settings/notebook.workingDirectory) setting.
+- To set the default working directory for a notebook, use the [`notebook.workingDirectory`](positron://settings/notebook.workingDirectory) setting.

--- a/jupyter-notebooks.qmd
+++ b/jupyter-notebooks.qmd
@@ -8,7 +8,7 @@ description: "Work with Jupyter Notebooks in Positron with built-in support for 
 Positron enhances Jupyter Notebooks in several key ways:
 
 -   Notebooks work out of the box. You do not need to install any additional dependencies into your Python or R environments.
--   Notebooks are integrated into the IDE. You can manage data sources in the [**Connections** pane](connections-pane.qmd), view data at a glance in the [**Variables** pane](variables-pane.qmd), explore data in depth with the [Data Explorer](data-explorer.qmd), and browse documentation in the [**Help** pane](help-pane.qmd).
+-   Notebooks are integrated into the IDE. You can manage data sources in the [Connections pane](connections-pane.qmd), view data at a glance in the [Variables pane](variables-pane.qmd), explore data in depth with the [Data Explorer](data-explorer.qmd), and browse documentation in the [Help pane](help-pane.qmd).
 -   Language features such as autocompletion and go-to-definition work seamlessly across notebooks and plaintext files.
 
 ![A Jupyter Notebook in Positron with a Python code cell, a monthly electricity usage chart as output, the Assistant panel open to the left, and the Variables pane open to the right.](images/positron-notebook.png){fig-alt="Positron IDE showing a Jupyter notebook with Python code, a bar chart of monthly electricity usage, the Positron Assistant chat panel on the left, and Variables pane on the right."}

--- a/jupyter-notebooks.qmd
+++ b/jupyter-notebooks.qmd
@@ -7,20 +7,20 @@ description: "Work with Jupyter Notebooks in Positron with built-in support for 
 
 Positron enhances Jupyter Notebooks in several key ways:
 
--   Notebooks work out of the box. You don't need to install any additional dependencies into your Python or R environments.
--   Notebooks are integrated into the IDE, allowing you to manage data sources in the [**Connections** pane](connections-pane.qmd), view data at a glance in the [**Variables** pane](variables-pane.qmd), explore data in depth with the [Data Explorer](data-explorer.qmd), and browse documentation in the [**Help** pane](help-pane.qmd).
+-   Notebooks work out of the box. You do not need to install any additional dependencies into your Python or R environments.
+-   Notebooks are integrated into the IDE. You can manage data sources in the [**Connections** pane](connections-pane.qmd), view data at a glance in the [**Variables** pane](variables-pane.qmd), explore data in depth with the [Data Explorer](data-explorer.qmd), and browse documentation in the [**Help** pane](help-pane.qmd).
 -   Language features such as autocompletion and go-to-definition work seamlessly across notebooks and plaintext files.
 
 ![A Jupyter Notebook in Positron with a Python code cell, a monthly electricity usage chart as output, the Assistant panel open to the left, and the Variables pane open to the right.](images/positron-notebook.png){fig-alt="Positron IDE showing a Jupyter notebook with Python code, a bar chart of monthly electricity usage, the Positron Assistant chat panel on the left, and Variables pane on the right."}
 
 ## Notebook editors
 
-Positron offers two editors for working with Jupyter Notebooks: the [Positron Notebook Editor](positron-notebook-editor.qmd) which is in alpha, and the [Legacy Notebook Editor](legacy-notebook-editor.qmd) which is the default VS Code based notebook editor.
+Positron offers two editors for working with Jupyter Notebooks: the [Positron Notebook Editor](positron-notebook-editor.qmd) which is in beta, and the [Legacy Notebook Editor](legacy-notebook-editor.qmd) which is the default VS Code based notebook editor.
 
 ### Positron Notebook Editor
 
-:::{.callout-important}
-The Positron Notebook Editor is in public alpha. We are actively working on improving the Notebook experience in Positron and want to hear from you! Share your thoughts on [this Github discussion](https://github.com/posit-dev/positron/discussions/10047) or [schedule a call](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) with our product and engineering team.
+:::{.callout-note}
+The Positron Notebook Editor is in public beta. We are actively working on improving the Notebook experience in Positron and want to hear from you! Share your thoughts on [this Github discussion](https://github.com/posit-dev/positron/discussions/10047) or [schedule a call](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) with our product and engineering team.
 :::
 
 The [Positron Notebook Editor](positron-notebook-editor.qmd) is a native notebook experience built specifically for Positron. It provides notebook-aware AI assistance, integrated data exploration, and an improved user experience for data science workflows. Check out the [launch article](https://posit.co/blog/announcing-the-positron-notebook-editor-for-jupyter-notebooks/) for more details.
@@ -31,4 +31,4 @@ To enable the Positron Notebook Editor, see the [setup instructions](positron-no
 
 ### Legacy notebook editor
 
-The [Legacy Notebook Editor](legacy-notebook-editor.qmd) is the default Code OSS based notebook editor. If you're familiar with Jupyter Notebooks in VS Code, this editor will feel familiar.
+The [Legacy Notebook Editor](legacy-notebook-editor.qmd) is the default Code OSS based notebook editor. If you are familiar with Jupyter Notebooks in VS Code, this editor will feel familiar.

--- a/legacy-notebook-editor.qmd
+++ b/legacy-notebook-editor.qmd
@@ -8,19 +8,21 @@ You can create and edit `.ipynb` files in Positron just as you would in other ed
 For a general introduction to working with Jupyter Notebooks, see the [VS Code Jupyter Notebooks documentation](https://code.visualstudio.com/docs/datascience/jupyter-notebooks).
 
 :::{.callout-note}
-Looking for integrated AI assistance, data exploration, and improved data science workflows? Try the [Positron Notebook Editor](positron-notebook-editor.qmd), currently in public alpha. Give it a try and share your feedback to help us build the best experience together!
+Looking for integrated AI assistance, data exploration, and improved data science workflows? Try the [Positron Notebook Editor](positron-notebook-editor.qmd), in public beta. Give it a try and share your feedback to help us build the best experience together!
 :::
 
 ### Setting up your environment
 
-Positron comes bundled with Jupyter kernel support for R and Python. Once you've [configured a Python or R environment](managing-interpreters.qmd) for Positron, you do not need to install any additional dependencies into your environment before using a notebook.
+Positron comes bundled with Jupyter kernel support for R and Python. Once you have [configured a Python or R environment](managing-interpreters.qmd) for Positron, you do not need to install any additional dependencies into your environment before using a notebook.
 
-If an environment installed on your computer isn't available in Positron, you may want to read more about how Positron discovers [Python installations](python-installations.qmd) and [R installations](r-installations.qmd).
+If an environment installed on your computer is not available in Positron, you may want to read more about how Positron discovers [Python installations](python-installations.qmd) and [R installations](r-installations.qmd).
 
 {{< include "_notebook-kernel-selection.qmd" >}}
 
 ![The Legacy Notebook Editor action bar with the kernel selector highlighted, showing Python 3.12.8 as the selected interpreter.](images/jupyter-notebooks-kernel-selector.png){fig-alt="Notebook Editor action bar with the kernel selector button highlighted, displaying Python 3.12.8 as the current kernel."}
 
-You can manually select a different interpreter for the notebook by selecting the **Kernel Selector** button in the notebook editor action bar or by running the *Notebook: Select Notebook Kernel* command from the Command Palette.
+You can select a different interpreter for the notebook by selecting the **Kernel Selector** button in the notebook editor action bar or by running the *Notebook: Select Notebook Kernel* command from the Command Palette.
+
+### Customization
 
 {{< include "_notebook-customization.qmd" >}}

--- a/positron-notebook-editor.qmd
+++ b/positron-notebook-editor.qmd
@@ -16,9 +16,9 @@ The Positron Notebook Editor provides a familiar notebook experience for Jupyter
 - **Batteries-included experience**: No extensions required for core features
 - **Improved user experience**: Optimized for data science workflows
 - **Notebook-aware AI assistance**: AI understands your notebook context, execution history, and execution order
-- **Integrated data exploration**: **Variables** pane and Data Explorer work seamlessly
+- **Integrated data exploration**: Variables pane and Data Explorer work seamlessly
 - **Debugging**: Works out of the box without additional setup
-- **Improved version control**: Control what metadata is saved and easily convert Jupyter notebooks to Quarto notebooks for better diffing and version control
+- **Improved version control**: Control what metadata is saved for better diffing and version control
 
 ## Enable the Positron Notebook Editor
 
@@ -52,9 +52,7 @@ Alternatively, you can run the *Positron Notebook: Change Kernel...* command fro
 
 ## Version control
 
-The Positron Notebook Editor controls what metadata is saved to the notebook file. This makes notebooks more version-control-friendly. By default, cell outputs are saved but execution counts are not. You can adjust this behavior with the [`notebook.save.outputs`](positron://settings/notebook.save.outputs) and [`notebook.save.executionCounts`](positron://settings/notebook.save.executionCounts) settings.
-
-For cleaner diffs, you can convert a Jupyter notebook to a Quarto notebook (`.qmd`) by running the _Quarto: Convert to Quarto Document_ command from the Command Palette. Quarto notebooks store code and markdown as plain text, making them easier to review in pull requests. For more information on Quarto convert see [the Quarto documentation](https://quarto.org/docs/cli/convert.html).
+The Positron Notebook Editor controls what metadata is saved to the notebook file. This makes notebooks more version-control-friendly. By default, cell outputs are saved but execution counts are not. You can adjust this behavior with the [Saving settings](#saving) below.
 
 ## Positron Assistant integration
 

--- a/positron-notebook-editor.qmd
+++ b/positron-notebook-editor.qmd
@@ -1,12 +1,12 @@
 ---
 title: "Positron Notebook Editor"
-description: "Use the Positron Notebook Editor, in public alpha, for a native notebook experience with integrated AI assistance, data exploration, and improved data science workflows."
+description: "Use the Positron Notebook Editor, in public beta, for a native notebook experience with integrated AI assistance, data exploration, and improved data science workflows."
 aliases:
   - notebooks-alpha.html
 ---
 
-::: {.callout-important} 
-The Positron Notebook Editor is in public alpha. Read [the launch blog post](https://posit.co/blog/announcing-the-positron-notebook-editor-for-jupyter-notebooks/) for more details. We are actively working on improving the Notebook experience in Positron and want to hear from you! Share your thoughts on [this Github discussion](https://github.com/posit-dev/positron/discussions/10047) or [schedule a call](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) with our product and engineering team.
+::: {.callout-note}
+The Positron Notebook Editor is in public beta. Read [the launch blog post](https://posit.co/blog/announcing-the-positron-notebook-editor-for-jupyter-notebooks/) for more details. We are actively working on improving the Notebook experience in Positron and want to hear from you! Share your thoughts on [this Github discussion](https://github.com/posit-dev/positron/discussions/10047) or [schedule a call](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) with our product and engineering team.
 :::
 
 The Positron Notebook Editor provides a familiar notebook experience for Jupyter (`.ipynb`) files. IDE features work out of the box in notebooks, including AI assistance, data exploration, and debugging.
@@ -18,10 +18,11 @@ The Positron Notebook Editor provides a familiar notebook experience for Jupyter
 - **Notebook-aware AI assistance**: AI understands your notebook context, execution history, and execution order
 - **Integrated data exploration**: **Variables** pane and Data Explorer work seamlessly
 - **Debugging**: Works out of the box without additional setup
+- **Improved version control**: Control what metadata is saved and easily convert Jupyter notebooks to Quarto notebooks for better diffing and version control
 
 ## Enable the Positron Notebook Editor
 
-To make the Positron Notebook Editor the default Jupyter Notebook editor, enable the [`positron.notebook.enabled`](positron://settings/positron.notebook.enabled) setting.
+To make the Positron Notebook Editor the default Jupyter Notebook editor, enable the [`positron.notebook.enabled`](positron://settings/positron.notebook.enabled) setting. Once enabled, all `.ipynb` files will open in the Positron Notebook Editor instead of the Legacy Notebook Editor.
 
 ## Getting started
 
@@ -37,29 +38,33 @@ To learn more about customizing the Positron interface, read the [Layout](layout
 
 ### Setting up your environment
 
-Positron comes bundled with Jupyter kernel support for R and Python. Once you've [configured a Python or R environment](managing-interpreters.qmd) for Positron, you do not need to install any additional dependencies into your environment before using a notebook.
+Positron comes bundled with Jupyter kernel support for R and Python. Once you have [configured a Python or R environment](managing-interpreters.qmd) for Positron, you do not need to install any additional dependencies into your environment before using a notebook.
 
-If an environment installed on your computer isn't available in Positron, you may want to read more about how Positron discovers [Python installations](python-installations.qmd) and [R installations](r-installations.qmd).
+If an environment installed on your computer is not available in Positron, you may want to read more about how Positron discovers [Python installations](python-installations.qmd) and [R installations](r-installations.qmd).
 
 {{< include "_notebook-kernel-selection.qmd" >}}
 
 ![The Positron Notebook Editor action bar with the kernel selector highlighted, showing Python 3.12.11 as the selected interpreter.](images/positron-notebook-editor-kernel-selector.png){fig-alt="Notebook Editor action bar with the kernel selector dropdown highlighted in red, showing Python 3.12.11 (Pyenv) selected."}
 
-You can select a different interpreter for the notebook by selecting the **Kernel Selector** in the notebook editor action bar. The **Change Kernel...** option will display a list of all the registered interpreters. Select an interpreter from the list. 
+You can select a different interpreter for the notebook by selecting the **Kernel Selector** in the notebook editor action bar. The **Change Kernel...** option will display a list of all the registered interpreters. Select an interpreter from the list.
 
 Alternatively, you can run the *Positron Notebook: Change Kernel...* command from the Command Palette.
 
-{{< include "_notebook-customization.qmd" >}}
+## Version control
+
+The Positron Notebook Editor controls what metadata is saved to the notebook file. This makes notebooks more version-control-friendly. By default, cell outputs are saved but execution counts are not. You can adjust this behavior with the [`notebook.save.outputs`](positron://settings/notebook.save.outputs) and [`notebook.save.executionCounts`](positron://settings/notebook.save.executionCounts) settings.
+
+For cleaner diffs, you can convert a Jupyter notebook to a Quarto notebook (`.qmd`) by running the _Quarto: Convert to Quarto Document_ command from the Command Palette. Quarto notebooks store code and markdown as plain text, making them easier to review in pull requests. For more information on Quarto convert see [the Quarto documentation](https://quarto.org/docs/cli/convert.html).
 
 ## Positron Assistant integration
 
 The Positron Notebook Editor integrates with [Positron Assistant](assistant.qmd) to provide notebook-aware AI assistance:
 
-- **Context-Aware**: Assistant has access to rich context about your notebook, including cell states, execution history, code and outputs including images and tables.
+- **Context-aware**: Assistant has access to rich context about your notebook, including cell states, execution history, code and outputs including images and tables.
 - **Dynamic Suggestions**: Assistant follows your work and dynamically suggests actions to improve your notebook.
 - **Actionable Editing**: With your permission, Assistant can directly edit and run cells in your notebook.
 - **Transparent**: You can inspect and control the specific context the Assistant is using.
-- **Collaborative**: Use [Follow Assistant](#follow-assistant) to automatically scroll and highlight cells as they're edited 
+- **Collaborative**: Use [Follow Assistant](#follow-assistant) to automatically scroll and highlight cells as they are edited
 
 {{< video videos/notebook-ai-quick-actions.mp4 aria-label="Using Positron Assistant to generate AI-powered suggestions and edits in a notebook" >}}
 
@@ -85,19 +90,54 @@ From the panel, you can:
 
 Selecting an option from the panel will open a new [**Chat** pane](assistant-chat.qmd) with the notebook context already attached.
 
+### Ghost cell suggestions (Experimental)
+
+Ghost cell suggestions use AI to predict your next step after you execute a cell. A ghost cell appears below the current cell with a suggested action you can accept, edit, or dismiss.
+
+To enable ghost cell suggestions, set [`positron.assistant.notebook.ghostCellSuggestions.enabled`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.enabled) to `true`. By default, suggestions appear automatically after cell execution. To instead trigger them manually, disable [`positron.assistant.notebook.ghostCellSuggestions.automatic`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.automatic) and click **Get Suggestion** or press {{< kbd mac=Command-Shift-G win=Ctrl-Shift-G linux=Ctrl-Shift-G >}}.
+
 ### Follow assistant
 
 When the Assistant is actively editing cells in your notebook, you may want to watch its progress. Select **Follow Assistant** in the notebook editor action bar to have the notebook automatically scroll to cells as they are edited. This lets you review changes in real-time.
 
-## Share your feedback 
+## Customization & Settings
+#### General
 
-We’d love your feedback. Please [book time to chat with us](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) or:
+- [`positron.notebook.enabled`](positron://settings/positron.notebook.enabled): Use the Positron Notebook Editor as the default editor for `.ipynb` files.
+- [`positron.notebook.experimental`](positron://settings/positron.notebook.experimental): Enable experimental Positron Notebook features. Experimental features may change or be removed in future releases.
+{{< include "_notebook-customization.qmd" >}}
 
-1. [File issues](https://github.com/posit-dev/positron/issues) for any bugs or improvements you want to see. 
+#### Saving
 
-2. Upvote on features you want to see next:
+- [`notebook.save.outputs`](positron://settings/notebook.save.outputs): Save outputs to the notebook file. Enabled by default.
+- [`notebook.save.executionCounts`](positron://settings/notebook.save.executionCounts): Save execution counts to the notebook file for version-control-friendly notebooks.
 
-   * [Features in exploration](https://github.com/posit-dev/positron/issues?q=is%3Aissue%20state%3Aopen%20label%3Anotebooks-roadmap)
+#### Inline Data Explorer
 
-   * [All open issues](https://github.com/posit-dev/positron/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22area%3A%20notebooks%22%20-label%3Anotebooks-alpha)
-   
+- [`positron.notebook.inlineDataExplorer.enabled`](positron://settings/positron.notebook.inlineDataExplorer.enabled): Display data frames inline as interactive data grids. Enabled by default.
+- [`positron.notebook.inlineDataExplorer.maxHeight`](positron://settings/positron.notebook.inlineDataExplorer.maxHeight): Set the maximum height in pixels for inline data explorers in notebook and Quarto outputs. Default to 300 pixels.
+
+#### Assistant
+
+- [`positron.assistant.notebookSuggestions.model`](positron://settings/positron.assistant.notebookSuggestions.model): Set the model used when generating AI suggestions in notebooks.
+- [`positron.assistant.notebook.deletionSentinel.show`](positron://settings/positron.assistant.notebook.deletionSentinel.show): Show deletion sentinels when cells are deleted. When disabled, cells are deleted immediately without undo placeholders. Enabled by default.
+- [`positron.assistant.notebook.deletionSentinel.timeout`](positron://settings/positron.assistant.notebook.deletionSentinel.timeout): Time in milliseconds before deletion sentinels auto-dismiss (0 to disable auto-dismiss).
+- [`positron.assistant.notebook.showDiff`](positron://settings/positron.assistant.notebook.showDiff): Show a diff view for AI assistant edits to notebook cells. When disabled, changes are applied directly without requiring approval. Enabled by default.
+
+#### Ghost cell suggestions (Experimental)
+
+- [`positron.assistant.notebook.ghostCellSuggestions.enabled`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.enabled): Show AI-generated suggestions for the next cell after successful cell execution. A ghost cell with a suggested next step will appear after a brief delay.
+- [`positron.assistant.notebook.ghostCellSuggestions.automatic`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.automatic): When enabled, suggestions appear automatically after cell execution. When disabled, a placeholder appears and you can request a suggestion by clicking **Get Suggestion** or pressing {{< kbd mac=Command-Shift-G win=Ctrl-Shift-G linux=Ctrl-Shift-G >}}.
+- [`positron.assistant.notebook.ghostCellSuggestions.delay`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.delay): Time in milliseconds to wait after cell execution before showing ghost cell suggestions.
+- [`positron.assistant.notebook.ghostCellSuggestions.maxVariables`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.maxVariables): Maximum number of session variables to include in ghost cell suggestion context. Variables are prioritized by relevance (DataFrames and tables first, then collections and scalars). Set to 0 to disable variable context.
+- [`positron.assistant.notebook.ghostCellSuggestions.model`](positron://settings/positron.assistant.notebook.ghostCellSuggestions.model): Model patterns for ghost cell suggestions. Patterns are tried in order until a match is found (case-insensitive partial matching). Falls back to the current chat session model, then the provider's model, then the first available model.
+
+
+## Share your feedback
+
+We'd love your feedback. Please [book time to chat with us](https://scheduler.zoom.us/cindy-tong/improving-the-positron-notebook-experience) or:
+
+1. [File issues](https://github.com/posit-dev/positron/issues) for any bugs or improvements you want to see.
+
+2. Upvote on [features](https://github.com/posit-dev/positron/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22area%3A%20notebooks-jupyter%22) you want to see next.
+


### PR DESCRIPTION
https://github.com/posit-dev/positron/issues/12520

## Summary
- Update all notebook documentation to reflect the editor's move from alpha to beta
- Add new sections: Version control, Ghost cell suggestions (Experimental), Customization & Settings
- Document all notebook-related settings (general, saving, inline data explorer, assistant, ghost cell suggestions)
- Apply Posit style guide fixes (contractions, callout types, sentence case headings, timeless language)
- Address PR review feedback: remove bold from pane names, remove Quarto convert language (not shipping), link to Saving settings subsection

## Test plan
- [ ] Run `quarto preview` and verify the Positron Notebook Editor page renders correctly
- [ ] Verify the Jupyter Notebooks page shows "beta" and uses `callout-note`
- [ ] Verify the Legacy Notebook Editor page shows "beta" without "currently"
- [ ] Check all `positron://settings/` links open correctly in Positron
- [ ] Verify the [Saving settings](#saving) link navigates to the correct subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)