### PR TITLE
Add docs for the Packages pane

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -173,6 +173,7 @@ website:
           contents:
             - managing-interpreters.qmd
             - interpreter-startup.qmd
+            - packages-pane.qmd
             - section: "Language-Specific Setup"
               contents:
                 - python-installations.qmd

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -159,6 +159,7 @@ website:
           contents:
             - managing-interpreters.qmd
             - interpreter-startup.qmd
+            - packages-pane.qmd
             - section: "Language-Specific Setup"
               contents:
                 - python-installations.qmd

--- a/packages-pane.qmd
+++ b/packages-pane.qmd
@@ -1,0 +1,52 @@
+---
+title: "Packages Pane"
+description: "Install, update, and uninstall packages in your active R or Python session without leaving Positron. Browse installed packages and search package repositories."
+---
+
+::: {.callout-important}
+The **Packages** pane is a preview feature. It is enabled by default and can be disabled via the [`positron.packages.enable`](positron://settings/positron.packages.enable) setting.
+:::
+
+The **Packages** pane provides an interface for managing the packages installed in your active R or Python session.
+You can browse installed packages, search package repositories, and install, update, or uninstall packages without leaving Positron.
+
+## Open the Packages pane
+
+The **Packages** pane is shown in the Primary Side Bar.
+If it is not already displayed, select the **Packages** icon ({{< fa box >}}) in the Activity Bar, or run _View: Packages_ from the Command Palette ({{< kbd mac=Command-Shift-P win=Ctrl-Shift-P linux=Ctrl-Shift-P >}}).
+
+## Browse installed packages
+
+The **Packages** pane lists packages installed in the active session's library.
+Each entry shows the package name, version, and an indicator of whether the package is currently attached.
+
+Use the filter input at the top of the pane to search by name.
+The filter menu also lets you limit the list to **Outdated** or **Attached** packages, and sort entries by name.
+
+For R sessions, "attached" mirrors membership in the R search path; a package can be loaded as a dependency without being attached.
+
+## Install a package
+
+1. Select **Install Package** in the **Packages** pane action bar, or run _Packages: Install Package_ from the Command Palette
+2. Enter a package name to search the configured repository
+3. Select a package and version from the results to install it into the active session
+
+## Update packages
+
+Packages with a newer version available in the configured repository are flagged as outdated.
+To update an outdated package, select it in the list, then select **Update Package** in the action bar.
+To update every outdated package at once, select **Update All Packages** in the action bar.
+
+You can also run _Packages: Update Package_ or _Packages: Update All Packages_ from the Command Palette.
+
+## Uninstall a package
+
+Select a package in the list, then select **Uninstall Package** in the action bar, or run _Packages: Uninstall Package_ from the Command Palette.
+
+After installing, updating, or uninstalling a package, Positron prompts you to restart the session so the changes take effect.
+
+## Settings
+
+| Setting | Description |
+|---------|-------------|
+| [`positron.packages.enable`](positron://settings/positron.packages.enable) | Show the **Packages** pane. |


### PR DESCRIPTION
The Packages pane is a new preview feature for managing R and Python packages in the active session. Add it to the Interpreters section of both Quarto profiles.

I added it to the "interpreters" section...

<img width="1275" height="989" alt="Screenshot 2026-04-30 at 1 46 46 PM" src="https://github.com/user-attachments/assets/f5b85b56-5962-4a19-84ef-21b737beabbf" />

<img width="478" height="307" alt="Screenshot 2026-04-30 at 1 44 16 PM" src="https://github.com/user-attachments/assets/7d75361a-4036-4ca2-a66e-0367ee9fa05e" />

