### PR TITLE
Update doc for Shiny apps

### DIFF
--- a/develop-data-apps.qmd
+++ b/develop-data-apps.qmd
@@ -9,29 +9,24 @@ Positron provides a simplified method for running interactive data apps via the 
 
 ## Supported app frameworks
 
-Positron supports the following app frameworks:
-
-**Python:**
+Currently, Positron supports the following Python app frameworks:
 
 - [Dash](https://dash.plotly.com/)
 - [FastAPI](https://fastapi.tiangolo.com/)
 - [Flask](https://flask.palletsprojects.com/en/stable/)
 - [Gradio](https://www.gradio.app/)
 - [Streamlit](https://streamlit.io/)
-
-**Python and R:**
-
-- [Shiny](https://shiny.posit.co/) via the [Shiny extension](https://open-vsx.org/extension/posit/shiny), included as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions)
+- [Shiny](https://shiny.posit.co/py/) via the [Shiny extension](https://open-vsx.org/extension/posit/shiny) which is included as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions)
 
 ## Running a data app
 
-1. Open the app file (`.py` or `.R`) of a supported app framework.
+1. Open the `.py` file of a supported app framework.
 2. In Editor Actions, select **Play**.
 
     ![Positron App Launcher Play button](images/run-app-play-button.png){fig-alt="Close-up of the Play button in the Editor action bar."}
 
-Positron opens the app URL in the **Viewer** pane. Python apps all run in a dedicated **Terminal** tab, while R Shiny apps run in a **Console** session (for a better debugging experience).
-If your Python application does not automatically open in the Viewer, check that the settings [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) and [`terminal.integrated.shellIntegration.enabled`](positron://settings/terminal.integrated.shellIntegration.enabled) are enabled.
+Then, Positron runs the app in a dedicated **Terminal** tab and opens the app URL in the **Viewer** pane.
+If your application does not automatically open in the Viewer, check that the settings [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) and [`terminal.integrated.shellIntegration.enabled`](positron://settings/terminal.integrated.shellIntegration.enabled) are enabled.
 
 ![A Streamlit app in the Positron Viewer](images/run-app-streamlit.png){fig-alt="Streamlit app running in the Positron Viewer pane showing a slider input and squared value output."}
 
@@ -42,11 +37,7 @@ To stop the app, you can either:
 
 ## Choosing where apps open
 
-By default, apps open in the **Viewer** pane. You can change this depending on how you launch the app.
-
-### Via the Play button {#play-button-preview}
-
-The [`positron.runApp.previewMode`](positron://settings/positron.runApp.previewMode) setting controls where the app opens:
+By default, apps open in the **Viewer** pane. The [`positron.runApp.previewMode`](positron://settings/positron.runApp.previewMode) setting controls where the app opens:
 
 | Value | Behavior |
 |-------|----------|
@@ -55,15 +46,7 @@ The [`positron.runApp.previewMode`](positron://settings/positron.runApp.previewM
 | `external` | Opens in the default external browser |
 | `none` | Does not open the app automatically |
 
-R Shiny apps use this setting by default. The [Shiny extension](https://open-vsx.org/extension/posit/shiny)'s [`shiny.previewType`](positron://settings/shiny.previewType) setting can override it, and is the primary control for Python Shiny apps.
-
-### From the Console {#console-preview}
-
-When you run an R Shiny app directly from the **Console** (e.g., with `shiny::runApp()`), the app opens in the **Viewer** pane by default. To change this behavior:
-
-- **To open in the external browser**: Set [`positron.viewer.openLocalhostUrls`](positron://settings/positron.viewer.openLocalhostUrls) to `false` in your Positron settings.
-
-- **To prevent the app from opening at all**: Set `options(shiny.launch.browser = FALSE)` or call `shiny::runApp(launch.browser = FALSE)`.
+Python Shiny apps use the [Shiny extension](https://open-vsx.org/extension/posit/shiny)'s [`shiny.previewType`](positron://settings/shiny.previewType) setting instead.
 
 ## Debugging a data app
 
@@ -79,5 +62,3 @@ When you run an R Shiny app directly from the **Console** (e.g., with `shiny::ru
 Then, Positron runs the app in a dedicated **Terminal** tab, opens the app URL in the **Viewer** pane, and starts the app in debug mode.
 
 ![A Streamlit app running in debug mode; paused at a breakpoint](images/run-app-debug-streamlit-paused-at-breakpoint.png){fig-alt="Positron IDE showing a Streamlit app paused at a breakpoint with the debug toolbar visible and Variables displayed in the Debug pane."}
-
-For debugging R Shiny apps, see [Debugging Shiny apps](guide-r-debugging.qmd#debugging-shiny-apps) in the R debugging guide.

--- a/develop-data-apps.qmd
+++ b/develop-data-apps.qmd
@@ -9,24 +9,29 @@ Positron provides a simplified method for running interactive data apps via the 
 
 ## Supported app frameworks
 
-Currently, Positron supports the following Python app frameworks:
+Positron supports the following app frameworks:
+
+**Python:**
 
 - [Dash](https://dash.plotly.com/)
 - [FastAPI](https://fastapi.tiangolo.com/)
 - [Flask](https://flask.palletsprojects.com/en/stable/)
 - [Gradio](https://www.gradio.app/)
 - [Streamlit](https://streamlit.io/)
-- [Shiny](https://shiny.posit.co/py/) via the [Shiny extension](https://open-vsx.org/extension/posit/shiny) which is included as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions)
+
+**Python and R:**
+
+- [Shiny](https://shiny.posit.co/) via the [Shiny extension](https://open-vsx.org/extension/posit/shiny), included as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions)
 
 ## Running a data app
 
-1. Open the `.py` file of a supported app framework.
+1. Open the app file (`.py` or `.R`) of a supported app framework.
 2. In Editor Actions, select **Play**.
 
     ![Positron App Launcher Play button](images/run-app-play-button.png){fig-alt="Close-up of the Play button in the Editor action bar."}
 
-Then, Positron runs the app in a dedicated **Terminal** tab and opens the app URL in the **Viewer** pane.
-If your application does not automatically open in the Viewer, check that the settings [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) and [`terminal.integrated.shellIntegration.enabled`](positron://settings/terminal.integrated.shellIntegration.enabled) are enabled.
+Positron opens the app URL in the **Viewer** pane. Python apps all run in a dedicated **Terminal** tab, while R Shiny apps run in a **Console** session (for a better debugging experience).
+If your Python application does not automatically open in the Viewer, check that the settings [`python.terminal.shellIntegration.enabled`](positron://settings/python.terminal.shellIntegration.enabled) and [`terminal.integrated.shellIntegration.enabled`](positron://settings/terminal.integrated.shellIntegration.enabled) are enabled.
 
 ![A Streamlit app in the Positron Viewer](images/run-app-streamlit.png){fig-alt="Streamlit app running in the Positron Viewer pane showing a slider input and squared value output."}
 
@@ -35,13 +40,38 @@ To stop the app, you can either:
 - Select the interrupt button in the **Viewer** pane toolbar.
 - Select the **Terminal** tab running the application and use the trash can icon to delete the **Terminal** or press {{< kbd Ctrl-C >}} to stop the process.
 
+## Choosing where apps open
+
+By default, apps open in the **Viewer** pane. You can change this depending on how you launch the app.
+
+### Via the Play button {#play-button-preview}
+
+The [`positron.runApp.previewMode`](positron://settings/positron.runApp.previewMode) setting controls where the app opens:
+
+| Value | Behavior |
+|-------|----------|
+| `viewer` | Opens in the **Viewer** pane (default) |
+| `editor` | Opens in an editor tab |
+| `external` | Opens in the default external browser |
+| `none` | Does not open the app automatically |
+
+R Shiny apps use this setting by default. The [Shiny extension](https://open-vsx.org/extension/posit/shiny)'s [`shiny.previewType`](positron://settings/shiny.previewType) setting can override it, and is the primary control for Python Shiny apps.
+
+### From the Console {#console-preview}
+
+When you run an R Shiny app directly from the **Console** (e.g., with `shiny::runApp()`), the app opens in the **Viewer** pane by default. To change this behavior:
+
+- **To open in the external browser**: Set [`positron.viewer.openLocalhostUrls`](positron://settings/positron.viewer.openLocalhostUrls) to `false` in your Positron settings.
+
+- **To prevent the app from opening at all**: Set `options(shiny.launch.browser = FALSE)` or call `shiny::runApp(launch.browser = FALSE)`.
+
 ## Debugging a data app
 
 1. Open the `.py` file of a supported app framework.
 2. Set breakpoints in the `.py` file by selecting the editor margin.
 
     ![Editor margin area for adding breakpoints](images/run-app-debug-breakpoint.png){fig-alt="Editor showing a red breakpoint dot in the left margin next to a line of Python code."}
-3. Select the **Play** button dropdown context menu and choose **Debug [*{SUPPORTED_APP_TYPE}*] App in Terminal**.  
+3. Select the **Play** button dropdown context menu and choose **Debug [*{SUPPORTED_APP_TYPE}*] App in Terminal**.
     - For this example, we select **Debug Steamlit App in Terminal**.
 
     ![Play button dropdown context menu](images/run-app-debug-streamlit.png){fig-alt="Play button dropdown menu showing options including Run Streamlit App in Terminal and Debug Streamlit App in Terminal."}

--- a/develop-data-apps.qmd
+++ b/develop-data-apps.qmd
@@ -79,3 +79,5 @@ When you run an R Shiny app directly from the **Console** (e.g., with `shiny::ru
 Then, Positron runs the app in a dedicated **Terminal** tab, opens the app URL in the **Viewer** pane, and starts the app in debug mode.
 
 ![A Streamlit app running in debug mode; paused at a breakpoint](images/run-app-debug-streamlit-paused-at-breakpoint.png){fig-alt="Positron IDE showing a Streamlit app paused at a breakpoint with the debug toolbar visible and Variables displayed in the Debug pane."}
+
+For debugging R Shiny apps, see [Debugging Shiny apps](guide-r-debugging.qmd#debugging-shiny-apps) in the R debugging guide.

--- a/guide-r-debugging.qmd
+++ b/guide-r-debugging.qmd
@@ -89,7 +89,7 @@ Prefix an expression with `/print` to display the full printed R output instead 
 
 ## Debugging Shiny apps
 
-Breakpoints work inside Shiny apps. You can place a breakpoint inside a reactive expression such as `renderPlot()`, then run the app with `shiny::runApp()`. The debugger pauses when R reaches the breakpoint.
+Breakpoints work inside Shiny apps. You can place a breakpoint inside a reactive expression such as `renderPlot()`, then run the app with `shiny::runApp()` or via the **Play** button. The debugger pauses when R reaches the breakpoint.
 
 :::{.callout-important}
 Install the latest version of the `shiny` package for full debugging support.

--- a/migrate-rstudio-settings-and-extensions.qmd
+++ b/migrate-rstudio-settings-and-extensions.qmd
@@ -84,6 +84,16 @@ You can opt into formatting your R code every time you save a file, using Air (r
 
 Read more about [formatting R code with Air](guide-r-air.qmd).
 
+### Shiny app preview
+
+In RStudio, setting `options(shiny.launch.browser = TRUE)` in your `.Rprofile` opens Shiny apps in the external browser instead of the internal viewer. In Positron, where the app opens depends on how you launch it:
+
+- **Via the Play button**: The [`positron.runApp.previewMode`](positron://settings/positron.runApp.previewMode) setting controls where the app opens. The [Shiny extension](https://open-vsx.org/extension/posit/shiny)'s [`shiny.previewType`](positron://settings/shiny.previewType) setting can override this.
+
+- **From the Console** (e.g., `shiny::runApp()`): Apps open in the **Viewer** pane by default. To open in the external browser instead, set [`positron.viewer.openLocalhostUrls`](positron://settings/positron.viewer.openLocalhostUrls) to `false`. Unlike in RStudio, the `shiny.launch.browser` R option only controls whether the app is opened at all (set it to `FALSE` to prevent the app from opening).
+
+See [Develop Data Apps](develop-data-apps.qmd#choosing-where-apps-open) for more details.
+
 ## Extensions for RStudio users
 
 You can use extensions to customize your IDE theme. For example, install [Tomorrow Night Bright (R Classic)](https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic) for an RStudio theme that has been ported to Positron.[^2]


### PR DESCRIPTION
Follow-up to:
- https://github.com/posit-dev/positron/issues/8450 
- https://github.com/posit-dev/shiny-vscode/pull/108
- https://github.com/posit-dev/positron/pull/12857
- https://github.com/posit-dev/positron/pull/12827

Documents:
- How to configure where to view apps, with the play button or via `runApp()`. The play button configuration also applies to other data apps.
- Brief mention that the play button can be used to debug R Shiny apps. 