### PR TITLE
Add a screenshot for 2026.05 in-product release-notes

### DIFF
--- a/release-notes/next.md
+++ b/release-notes/next.md
@@ -12,7 +12,11 @@ Welcome to the 2026.05.0 release of Positron!
 
 #### Announcing the Packages pane
 
-Our Packages pane is available in this release as a preview feature. The new Packages pane brings streamlined package management directly into the IDE so you can see at a glance what's installed, what's attached, and what's out of date. Find it in the Primary Sidebar by clicking the package icon. Positron automatically detects and integrates with your current interpreter; today we have support for pip, venv, uv, and conda for Python, plus base R, pak, and renv for R. You can search, sort, install, update, remove, filter by category (including "Outdated Packages"), and even see which packages are attached in your current session. To hide the pane, disable [`positron.packages.enable`](positron://settings/positron.packages.enable). [Let us know](https://github.com/posit-dev/positron/discussions) how it fits into your workflow.
+Our Packages pane is available in this release as a preview feature. The new Packages pane brings streamlined package management directly into the IDE so you can see at a glance what's installed, what's attached, and what's out of date. 
+
+<img src="https://cdn.posit.co/positron/releases/release-notes/assets/2026-05-packages-pane.png" alt="The Packages pane showing installed Python packages">
+
+Find it in the Primary Sidebar by clicking the package icon. Positron automatically detects and integrates with your current interpreter; today we have support for pip, venv, uv, and conda for Python, plus base R, pak, and renv for R. You can search, sort, install, update, remove, filter by category (including "Outdated Packages"), and even see which packages are attached in your current session. To hide the pane, disable [`positron.packages.enable`](positron://settings/positron.packages.enable). [Let us know](https://github.com/posit-dev/positron/discussions) how it fits into your workflow.
 
 #### Inline output for Quarto
 


### PR DESCRIPTION
This is what this looks like now:

<img width="675" height="982" alt="Screenshot 2026-05-04 at 8 43 58 AM" src="https://github.com/user-attachments/assets/e8210aa8-702f-41a0-81d6-029e2aad4d10" />

Seems to be working correctly!