### PR TITLE
Fix manual `workflow_dispatch` for regular monthly releases

### DIFF
--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -43,6 +43,11 @@ on:
         default: releases
         required: true
         type: choice
+      create_release:
+        description: 'Create a new GitHub release (uncheck to upload assets to an existing release)'
+        required: false
+        type: boolean
+        default: true
 
 name: Release Documentation Bundles
 


### PR DESCRIPTION
#337 added a `create_release` input to gate whether the workflow creates a new GitHub release or uploads assets to an existing one, but only declared it under `workflow_call`. Manual `workflow_dispatch` runs evaluated `inputs.create_release` as empty, skipped "Create Release", and fell through to "Upload assets to existing release", which failed with `release not found` (e.g. the run I just did for today's release: https://github.com/posit-dev/positron-website/actions/runs/25339184081).

This PR adds `create_release` to the `workflow_dispatch` inputs with `default: true` so manual runs create a fresh release by default, with a checkbox to opt into the upload-only path. The `workflow_call` caller in `posit-dev/positron-builds` (`update-workbench.yml`) is unaffected; it passes `create_release: false` explicitly.
