### PR TITLE
Add 502 (Bad Gateway) to accepted status codes in lychee config

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -11,5 +11,6 @@ exclude = [
 ]
 
 # 403 (Forbidden) and 429 (Too Many Requests) are returned by sites that
-# block automated requests, not broken links.
-accept = [200, 403, 429]
+# block automated requests, not broken links. 502 (Bad Gateway) is a
+# transient upstream error (e.g. open-vsx.org), not a broken link.
+accept = [200, 403, 429, 502]


### PR DESCRIPTION
helps avoid openvsx link lint errors that I saw in https://github.com/posit-dev/positron-website/actions/runs/25220317135#summary-73950641259

> Errors in assistant-chat-commands-participants.qmd
> [502] https://open-vsx.org/extension/posit/shiny | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> Errors in develop-data-apps.qmd
> [502] https://open-vsx.org/extension/posit/shiny | Error (cached)
> Errors in extensions.qmd
> [502] https://open-vsx.org/extension/posit/air-vscode | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/extension/posit/shiny | Error (cached)
> [502] https://open-vsx.org/extension/quarto/quarto | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> Errors in git.qmd
> [502] https://open-vsx.org/extension/atlassian/atlascode | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/extension/GitLab/gitlab-workflow | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/extension/vscode/github | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/vscode/item?itemName=eamodio.gitlens | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> Errors in migrate-rstudio-rproj.qmd
> [502] https://open-vsx.org/extension/alefragnani/project-manager | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> Errors in migrate-rstudio-settings-and-extensions.qmd
> [502] https://open-vsx.org/extension/GitHub/vscode-github-actions | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/extension/GitLab/gitlab-workflow | Error (cached)
> [502] https://open-vsx.org/extension/gvelasq/tomorrow-night-bright-r-classic | Rejected status code: 502 Bad Gateway (configurable with "accept" option)
> [502] https://open-vsx.org/extension/oderwat/indent-rainbow | Rejected status code: 502 Bad Gateway (configurable with "accept" option)