### PR TITLE
Add inline output docs

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -153,7 +153,12 @@ website:
             - catalog-explorer.qmd
         - section: "Dynamic Documents and Apps"
           contents:
-            - quarto.qmd
+            - section: "Quarto"
+              href: quarto.qmd
+              contents:
+                - text: "Overview"
+                  href: quarto.qmd
+                - quarto-inline-output.qmd
             - section: "Jupyter Notebooks"
               href: jupyter-notebooks.qmd
               contents:

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -152,7 +152,12 @@ website:
             - catalog-explorer.qmd
         - section: "Dynamic Documents and Apps"
           contents:
-            - quarto.qmd
+            - section: "Quarto"
+              href: quarto.qmd
+              contents:
+                - text: "Overview"
+                  href: quarto.qmd
+                - quarto-inline-output.qmd
             - section: "Jupyter Notebooks"
               href: jupyter-notebooks.qmd
               contents:

--- a/quarto-inline-output.qmd
+++ b/quarto-inline-output.qmd
@@ -10,6 +10,7 @@ Positron can optionally display the output of Quarto cells in the source editor,
 When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the Console where you have Python or R running.
 
 ```{mermaid}
+%%| fig-align: center
 graph LR
 q1[Quarto Doc 1] --> rc[Console]
 q2[Quarto Doc 2] --> rc
@@ -19,6 +20,7 @@ q3[Quarto Doc 3] --> rc
 When inline output is enabled, the execution model changes, and the Quarto document behaves more like a Jupyter Notebook. Positron creates an isolated Python or R session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
 
 ```{mermaid}
+%%| fig-align: center
 graph LR
 q1[Quarto Doc 1] --> rc1[Interpreter Session 1]
 q2[Quarto Doc 2] --> rc2[Interpreter Session 2]

--- a/quarto-inline-output.qmd
+++ b/quarto-inline-output.qmd
@@ -1,0 +1,51 @@
+---
+title: "Inline Output"
+description: "Display the output of Quarto cells directly in the source editor in Positron."
+---
+
+Positron can optionally display the output of Quarto cells in the source editor, similar to a [Jupyter Notebook](jupyter-notebooks.qmd) or RStudio's [R Notebooks](https://posit.co/blog/r-notebooks) feature. To enable inline output, turn on [`positron.quarto.inlineOutput.enabled`](positron://settings/positron.quarto.inlineOutput.enabled).
+
+## Per-document kernels
+
+When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the Console where you have Python or R running.
+
+```{mermaid}
+graph LR
+q1[Quarto Doc 1] --> rc[Console]
+q2[Quarto Doc 2] --> rc
+q3[Quarto Doc 3] --> rc
+```
+
+When inline output is enabled, the execution model changes, and the Quarto document behaves more like a Jupyter Notebook. Positron creates an isolated Python or R session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
+
+```{mermaid}
+graph LR
+q1[Quarto Doc 1] --> rc1[Interpreter Session 1]
+q2[Quarto Doc 2] --> rc2[Interpreter Session 2]
+q3[Quarto Doc 3] --> rc3[Interpreter Session 3]
+```
+
+## Consoles
+
+By default, a Quarto document with inline output enabled behaves like a Jupyter Notebook, and notebooks don't have consoles by default. To pair a console with your document, run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
+
+To always show a console for your Quarto documents as well as your Jupyter Notebooks, enable the _Console: Show Notebook Consoles_ setting.
+
+## Managing outputs
+
+Positron creates and saves output as you run code in the document. To clear the output for a document, run the _Quarto: Clear All Outputs_ command.
+
+Positron caches Quarto cell outputs separately from the document in its global state directory. In typical situations, you don't need to manage the cache, but if you are concerned about space usage or need to reset the cache, run the _Quarto: Clear Inline Output Cache_ command.
+
+## Limitations
+
+Inline output for Quarto documents is a new feature in Positron, and has some differences from the RStudio implementation you may be familiar with. The following limitations apply; links go to GitHub issues.
+
+- HTML widgets and other [interactive HTML content are not supported](https://github.com/posit-dev/positron/issues/4219).
+- You [cannot share a single R or Python session among multiple Quarto documents](https://github.com/posit-dev/positron/issues/12732).
+- Execution indicators in the gutter [do not track progress line by line](https://github.com/posit-dev/positron/issues/13505).
+- There is [no real-time preview for LaTeX equations](https://github.com/posit-dev/positron/issues/13288).
+- Documents containing a mix of R and Python [are not executed with Reticulate](https://github.com/posit-dev/positron/issues/13161).
+- Quarto documents in subfolders [don't run the parent .Rprofile or renv scripts](https://github.com/posit-dev/positron/issues/4695).
+- Positron reads execution options (such as width and height) only from Quarto-style options (`#| width: foo`), not from Knitr-style chunk-header options (`{width=foo}`).
+- `input()` in Python, `readline()` in R, and other [functions that read user input do not work](https://github.com/posit-dev/positron/issues/13050) in inline cells.

--- a/quarto-inline-output.qmd
+++ b/quarto-inline-output.qmd
@@ -29,7 +29,7 @@ q3[Quarto Doc 3] --> rc3[Interpreter Session 3]
 
 By default, a Quarto document with inline output enabled behaves like a Jupyter Notebook, and notebooks don't have consoles by default. To pair a console with your document, run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
 
-To always show a console for your Quarto documents as well as your Jupyter Notebooks, enable the _Console: Show Notebook Consoles_ setting.
+To always show a console for your Quarto documents as well as your Jupyter Notebooks, turn on [`console.showNotebookConsoles`](positron://settings/console.showNotebookConsoles).
 
 ## Managing outputs
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -21,33 +21,33 @@ Quarto's [visual editor](https://quarto.org/docs/tools/positron/visual-editor.ht
 
 ## Inline output
 
-Positron can optionally display the output of Quarto cells in the source editor, similar to RStudio's [R Notebooks](https://posit.co/blog/r-notebooks) feature. To enable inline output, turn on [`positron.quarto.inlineOutput.enabled`](positron://settings/positron.quarto.inlineOutput.enabled).
+Positron can optionally display the output of Quarto cells in the source editor, similar to a [Jupyter Notebook](jupyter-notebooks.qmd) or RStudio's [R Notebooks](https://posit.co/blog/r-notebooks) feature. To enable inline output, turn on [`positron.quarto.inlineOutput.enabled`](positron://settings/positron.quarto.inlineOutput.enabled).
 
 ### Per-document kernels
 
-When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the R Console.
+When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the Console where you have Python or R running.
 
 ```{mermaid}
 graph LR
-q1[Quarto Doc 1] --> rc[R Console]
+q1[Quarto Doc 1] --> rc[Console]
 q2[Quarto Doc 2] --> rc
 q3[Quarto Doc 3] --> rc
 ```
 
-When inline output is enabled, the execution model changes, and the Quarto document behaves more like a notebook. Positron creates an isolated R or Python session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
+When inline output is enabled, the execution model changes, and the Quarto document behaves more like a Jupyter Notebook. Positron creates an isolated Python or R session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
 
 ```{mermaid}
 graph LR
-q1[Quarto Doc 1] --> rc1[R Session 1]
-q2[Quarto Doc 2] --> rc2[R Session 2]
-q3[Quarto Doc 3] --> rc3[R Session 3]
+q1[Quarto Doc 1] --> rc1[Kernel Session 1]
+q2[Quarto Doc 2] --> rc2[Kernel Session 2]
+q3[Quarto Doc 3] --> rc3[Kernel Session 3]
 ```
 
 ### Consoles
 
-By default, a Quarto document with inline output enabled behaves like a notebook, and notebooks don't have consoles by default. To pair a console with your document (like RStudio), run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
+By default, a Quarto document with inline output enabled behaves like a Jupyter Notebook, and notebooks don't have consoles by default. To pair a console with your document, run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
 
-To always show a console for your Quarto documents, enable the _Console: Show Notebook Consoles_ command.
+To always show a console for your Quarto documents as well as your Jupyter Notebooks, enable the _Console: Show Notebook Consoles_ command.
 
 ### Managing outputs
 
@@ -65,8 +65,8 @@ Inline output for Quarto documents is a new feature in Positron, and has some di
 - There is [no real-time preview for LaTeX equations](https://github.com/posit-dev/positron/issues/13288).
 - Documents containing a mix of R and Python [are not executed with Reticulate](https://github.com/posit-dev/positron/issues/13161).
 - Quarto documents in subfolders [don't run the parent .Rprofile or renv scripts](https://github.com/posit-dev/positron/issues/4695).
-- Positron reads execution options (such as width and height) only from Jupyter-style options (`#| width: foo`), not from Knitr-style chunk-header options (`{width=foo}`).
-- `readline()` and other [functions that read user input do not work](https://github.com/posit-dev/positron/issues/13050) in inline cells.
+- Positron reads execution options (such as width and height) only from Quarto-style options (`#| width: foo`), not from Knitr-style chunk-header options (`{width=foo}`).
+- `input()` in Python, `readline()` in R, and other [functions that read user input do not work](https://github.com/posit-dev/positron/issues/13050) in inline cells.
 
 
 ## Support for R Markdown

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -28,6 +28,7 @@ Positron can optionally display the output of Quarto cells in the source editor,
 When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the R Console.
 
 ```{mermaid}
+graph LR
 q1[Quarto Doc 1] --> rc[R Console]
 q2[Quarto Doc 2] --> rc
 q3[Quarto Doc 3] --> rc
@@ -36,6 +37,7 @@ q3[Quarto Doc 3] --> rc
 When inline output is enabled, the execution model changes, and the Quarto document behaves more like a notebook. Positron creates an isolated R or Python session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
 
 ```{mermaid}
+graph LR
 q1[Quarto Doc 1] --> rc1[R Session 1]
 q2[Quarto Doc 2] --> rc2[R Session 2]
 q3[Quarto Doc 3] --> rc3[R Session 3]

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -9,7 +9,8 @@ Positron enhances how you can use Quarto in several important ways:
 
 - Quarto works out of the box in Positron. The Quarto CLI is bundled in Positron, and the Quarto extension is included as a [bootstrapped extension](extensions.qmd#bootstrapped-extensions).
 - Features such as statement execution work seamlessly in Positron's Console, and Positron supports integrated rendering and preview of Quarto documents.
-- Positron provides rich UI via [custom action bars](action-bars.qmd) to preview your Quarto document, control rendering behavior, and switch between source and visual mode,
+- Positron provides rich UI via [custom action bars](action-bars.qmd) to preview your Quarto document, control rendering behavior, and switch between source and visual mode.
+- Positron can optionally display cell output directly in the source editor; see [Inline Output](quarto-inline-output.qmd) for details.
 
 ![A Quarto document in Positron, with narrative, executable code chunks, and the rendered preview in Positron's integrated Viewer pane.](images/quarto-hello-python.png){width=700}
 
@@ -18,56 +19,6 @@ Learn more in the Quarto documentation about [getting started with Quarto and Po
 :::{.callout-note}
 Quarto's [visual editor](https://quarto.org/docs/tools/positron/visual-editor.html) has limited support in Positron. It is a great fit for rich text authoring, but statement execution and other language features are not supported. Consider switching to source mode when you need such features, and [follow along on GitHub for updates](https://github.com/posit-dev/positron/issues/1805) on this support.
 :::
-
-## Inline output
-
-Positron can optionally display the output of Quarto cells in the source editor, similar to a [Jupyter Notebook](jupyter-notebooks.qmd) or RStudio's [R Notebooks](https://posit.co/blog/r-notebooks) feature. To enable inline output, turn on [`positron.quarto.inlineOutput.enabled`](positron://settings/positron.quarto.inlineOutput.enabled).
-
-### Per-document kernels
-
-When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the Console where you have Python or R running.
-
-```{mermaid}
-graph LR
-q1[Quarto Doc 1] --> rc[Console]
-q2[Quarto Doc 2] --> rc
-q3[Quarto Doc 3] --> rc
-```
-
-When inline output is enabled, the execution model changes, and the Quarto document behaves more like a Jupyter Notebook. Positron creates an isolated Python or R session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
-
-```{mermaid}
-graph LR
-q1[Quarto Doc 1] --> rc1[Kernel Session 1]
-q2[Quarto Doc 2] --> rc2[Kernel Session 2]
-q3[Quarto Doc 3] --> rc3[Kernel Session 3]
-```
-
-### Consoles
-
-By default, a Quarto document with inline output enabled behaves like a Jupyter Notebook, and notebooks don't have consoles by default. To pair a console with your document, run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
-
-To always show a console for your Quarto documents as well as your Jupyter Notebooks, enable the _Console: Show Notebook Consoles_ command.
-
-### Managing outputs
-
-Positron creates and saves output as you run code in the document. To clear the output for a document, run the _Quarto: Clear All Outputs_ command.
-
-Positron caches Quarto cell outputs separately from the document in its global state directory. In typical situations, you don't need to manage the cache, but if you are concerned about space usage or need to reset the cache, run the _Quarto: Clear Inline Output Cache_ command.
-
-### Limitations
-
-Inline output for Quarto documents is a new feature in Positron, and has some differences from the RStudio implementation you may be familiar with. The following limitations apply; links go to GitHub issues.
-
-- HTML widgets and other [interactive HTML content are not supported](https://github.com/posit-dev/positron/issues/4219).
-- You [cannot share a single R or Python session among multiple Quarto documents](https://github.com/posit-dev/positron/issues/12732).
-- Execution indicators in the gutter [do not track progress line by line](https://github.com/posit-dev/positron/issues/13505).
-- There is [no real-time preview for LaTeX equations](https://github.com/posit-dev/positron/issues/13288).
-- Documents containing a mix of R and Python [are not executed with Reticulate](https://github.com/posit-dev/positron/issues/13161).
-- Quarto documents in subfolders [don't run the parent .Rprofile or renv scripts](https://github.com/posit-dev/positron/issues/4695).
-- Positron reads execution options (such as width and height) only from Quarto-style options (`#| width: foo`), not from Knitr-style chunk-header options (`{width=foo}`).
-- `input()` in Python, `readline()` in R, and other [functions that read user input do not work](https://github.com/posit-dev/positron/issues/13050) in inline cells.
-
 
 ## Support for R Markdown
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -19,6 +19,54 @@ Learn more in the Quarto documentation about [getting started with Quarto and Po
 Quarto's [visual editor](https://quarto.org/docs/tools/positron/visual-editor.html) has limited support in Positron. It is a great fit for rich text authoring, but statement execution and other language features are not supported. Consider switching to source mode when you need such features, and [follow along on GitHub for updates](https://github.com/posit-dev/positron/issues/1805) on this support.
 :::
 
+## Inline output
+
+Positron can optionally display the output of Quarto cells in the source editor, similar to RStudio's [R Notebooks](https://posit.co/blog/r-notebooks) feature. To enable inline output, turn on [`positron.quarto.inlineOutput.enabled`](positron://settings/positron.quarto.inlineOutput.enabled).
+
+### Per-document kernels
+
+When inline output is disabled, Positron's Quarto execution model is similar to RStudio's; running code from a Quarto cell sends it to the R Console.
+
+```{mermaid}
+q1[Quarto Doc 1] --> rc[R Console]
+q2[Quarto Doc 2] --> rc
+q3[Quarto Doc 3] --> rc
+```
+
+When inline output is enabled, the execution model changes, and the Quarto document behaves more like a notebook. Positron creates an isolated R or Python session for each `.qmd` file. This matches typical render-time behavior, improves reproducibility by using a clean environment for each document, and resolves ambiguities around working directories.
+
+```{mermaid}
+q1[Quarto Doc 1] --> rc1[R Session 1]
+q2[Quarto Doc 2] --> rc2[R Session 2]
+q3[Quarto Doc 3] --> rc3[R Session 3]
+```
+
+### Consoles
+
+By default, a Quarto document with inline output enabled behaves like a notebook, and notebooks don't have consoles by default. To pair a console with your document (like RStudio), run the _Console: Show Notebook Console_ command. Notebook consoles let you execute code in the same session used by your Quarto document without changing the document itself, and they echo any code you run from the editor.
+
+To always show a console for your Quarto documents, enable the _Console: Show Notebook Consoles_ command.
+
+### Managing outputs
+
+Positron creates and saves output as you run code in the document. To clear the output for a document, run the _Quarto: Clear All Outputs_ command.
+
+Positron caches Quarto cell outputs separately from the document in its global state directory. In typical situations, you don't need to manage the cache, but if you are concerned about space usage or need to reset the cache, run the _Quarto: Clear Inline Output Cache_ command.
+
+### Limitations
+
+Inline output for Quarto documents is a new feature in Positron, and has some differences from the RStudio implementation you may be familiar with. The following limitations apply; links go to GitHub issues.
+
+- HTML widgets and other [interactive HTML content are not supported](https://github.com/posit-dev/positron/issues/4219).
+- You [cannot share a single R or Python session among multiple Quarto documents](https://github.com/posit-dev/positron/issues/12732).
+- Execution indicators in the gutter [do not track progress line by line](https://github.com/posit-dev/positron/issues/13505).
+- There is [no real-time preview for LaTeX equations](https://github.com/posit-dev/positron/issues/13288).
+- Documents containing a mix of R and Python [are not executed with Reticulate](https://github.com/posit-dev/positron/issues/13161).
+- Quarto documents in subfolders [don't run the parent .Rprofile or renv scripts](https://github.com/posit-dev/positron/issues/4695).
+- Positron reads execution options (such as width and height) only from Jupyter-style options (`#| width: foo`), not from Knitr-style chunk-header options (`{width=foo}`).
+- `readline()` and other [functions that read user input do not work](https://github.com/posit-dev/positron/issues/13050) in inline cells.
+
+
 ## Support for R Markdown
 
 Quarto provides Positron's support for [R Markdown](https://rmarkdown.rstudio.com/); there is limited specialized IDE support for R Markdown other than what is provided by Quarto. Some advanced `.Rmd` features like using `params` are not supported for interactive use. 


### PR DESCRIPTION
Adds documentation on Quarto inline output.

The documentation is oriented around helping people understand how the feature works in Positron specifically rather than being a comprehensive user guide about how to run code, etc, and tries to address the most common gotchas that we get questions about:

- the execution model (per document vs global)
- consoles
- things that don't work yet (and may never work)