### PR TITLE
Add Posit AI Next Edit Suggestions docs

### DIFF
--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -1,56 +1,105 @@
 ---
 title: "Completions"
-description: "Boost your productivity with AI code suggestions via Github Copilot completions. Inline suggestions support faster coding in Python, R, and more."
+description: "Boost your productivity with AI code suggestions via Posit AI Next Edit Suggestions or GitHub Copilot completions. Inline suggestions support faster coding in Python, R, and more."
 ---
 
 Code completions are text suggestions that appear inline as you type in an editor. These suggestions can be lines or blocks of code based on the context of what you're writing. Other names for code completions include inline suggestions, ghost text, or inline completions.
 
 ::: {.callout-important}
-Completions are powered by **GitHub Copilot**. Ensure you've [added GitHub Copilot as a language model provider](assistant-getting-started.qmd#add-github-copilot-as-a-language-model-provider).
+Completions are powered by Posit AI or GitHub Copilot. Ensure you've added one or both of these as a language model provider:
+
+- [Add Posit AI as a language model provider](assistant-getting-started.qmd#add-posit-ai-as-a-language-model-provider)
+- [Add GitHub Copilot as a language model provider](assistant-getting-started.qmd#add-github-copilot-as-a-language-model-provider)
 :::
 
 ## Using code completions
 
-When code completions are available, you'll see ghost text appear in your editor as you type. The ghost text represents the suggested completion.
+When code completions are available, ghost text appears in your editor as you type. The ghost text represents the suggested completion.
 
 Interact with suggestions by:
 
 - Pressing the {{< kbd Tab >}} key to accept the entire suggestion.
-- Pressing {{< kbd mac=Command-→ win=Ctrl-→ linux=Ctrl-→ >}} to accept the suggestion word-by-word for a single line suggestion, or line-by-line for multi-line suggestions.
+- Pressing {{< kbd mac=Command-→ win=Ctrl-→ linux=Ctrl-→ >}} to accept the suggestion word-by-word for a single-line suggestion, or line-by-line for multi-line suggestions.
 - Pressing {{< kbd Esc >}} or continuing to type to dismiss the suggestion.
 
-If you are not receiving suggestions:
+### Commands
 
-- Check if you've enabled inline completions in the settings (see [Settings](#settings) below).
-- Check that completions aren't snoozed (paused). If they are, you can either wait for the snooze period to end or cancel the snooze.
-- Make sure you are authenticated with GitHub Copilot in the [language model provider configuration](assistant-getting-started.qmd#add-github-copilot-as-a-language-model-provider).
-- Refer to the [Troubleshooting](assistant-troubleshooting.qmd) guide for more help.
-
-To learn more about GitHub Copilot code completions, visit the GitHub Copilot [inline suggestions](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions#_getting-your-first-suggestions) documentation. Note that Positron Assistant does not support Next Edit Suggestions (NES).
-
-## Commands
+The following commands apply to both providers:
 
 | Command | Description |
 | --- | --- |
-| _Positron Assistant: Toggle (Enable/Disable) Completions_ | Enable or disable code completions from Positron Assistant altogether. |
-| _Snooze Inline Suggestions_ | Pause code completions temporarily for a specified duration. |
-| _Cancel Snooze Inline Suggestions_ | Resume code completions immediately if they have been snoozed. |
+| _Snooze Inline Suggestions_ | Pause inline suggestions temporarily for a specified duration. |
+| _Cancel Snooze Inline Suggestions_ | Resume inline suggestions immediately if they have been snoozed. |
 
-## Settings
+### Settings {#shared-settings}
 
-- [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable): Enable or disable code completions altogether.
+The following settings apply to both providers:
 
-- [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes): Files matching these patterns will not have their contents sent to AI providers for inline completions or chat context.
-
+- [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes): Files matching these patterns will not have their contents sent to AI providers for code completions or chat context.
 - [`editor.inlineSuggest.minShowDelay`](positron://settings/editor.inlineSuggest.minShowDelay): Delay in milliseconds before showing inline suggestions. For example, setting this to `500` will show suggestions half a second after typing.
 
-## Status bar icon
+## Posit AI Next Edit Suggestions (NES)
 
-The Assistant status bar icon indicates the current state of code completions from Positron Assistant.
+When using Posit AI as your completions provider, code completions take the form of Posit AI Next Edit Suggestions (NES), a preview feature. Rather than only suggesting text at the cursor position, Posit AI NES proposes edits anywhere in the file based on the changes you've recently made, including insertions, deletions, and modifications to existing code.
+
+Posit AI NES suggestions appear inline in the editor. You can accept, navigate, or dismiss them using the same keybindings as other code completions.
+
+### Enable
+
+Posit AI NES is enabled by default once you've [signed in to the Posit AI provider](assistant-getting-started.qmd#add-posit-ai-as-a-language-model-provider). No additional setting changes are required.
+
+### Restrict to specific languages
+
+Posit AI NES skips `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`nextEditSuggestions.enable`](positron://settings/nextEditSuggestions.enable) setting to change which languages Posit AI NES applies to.
+
+### Disable
+
+To disable Posit AI NES, do any of the following:
+
+- Sign out of Posit AI in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects chat and other features that rely on the account.
+- Set [`nextEditSuggestions.enable`](positron://settings/nextEditSuggestions.enable) to `{ "*": false }` to disable Posit AI NES everywhere. To disable only some languages, set those entries to `false`.
+
+To exclude specific files from Posit AI NES regardless of language, use the shared [`aiExcludes`](#shared-settings) setting.
+
+## GitHub Copilot
+
+When using GitHub Copilot as your completions provider, code completions appear as ghost text at the cursor position as you type. To learn more, visit the GitHub Copilot [inline suggestions](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions#_getting-your-first-suggestions) documentation.
+
+### Enable
+
+GitHub Copilot completions are enabled by default once you've [signed in to the GitHub Copilot provider](assistant-getting-started.qmd#add-github-copilot-as-a-language-model-provider). No additional setting changes are required.
+
+### Restrict to specific languages
+
+GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) setting to change which languages Copilot completions apply to.
+
+### Disable
+
+To disable GitHub Copilot completions, do any of the following:
+
+- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects chat and other features that rely on the account.
+- Run the _Positron Assistant: Toggle (Enable/Disable) Completions_ command to toggle Copilot completions for the current language. This command updates [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) for the active language.
+- Set [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) to `{ "*": false }` to disable Copilot completions everywhere. To disable only some languages, set those entries to `false`.
+- Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to disable completions at the upstream GitHub Copilot extension level.
+
+To exclude specific files from Copilot completions regardless of language, use the shared [`aiExcludes`](#shared-settings) setting.
+
+### Status bar icon
+
+The Assistant status bar icon indicates the current state of GitHub Copilot completions.
 
 ![Assistant status bar icon](images/assistant-status-bar-icon.png){width=750}
 
-To manage code completions using the status bar icon:
+To manage Copilot completions using the status bar icon:
 
-1. Select the status bar icon to open the popup.
-2. From the popup, you can enable or disable completions for the current file type, or for all files, or view the remaining time for snoozed completions.
+1. Select the status bar icon to open the menu.
+2. From the menu, enable or disable completions for the current file type or for all files, or view the remaining time for snoozed completions.
+
+## Troubleshooting
+
+If you are not receiving suggestions:
+
+- Confirm you are signed in to your completions provider in the [language model provider configuration](assistant-getting-started.qmd#step-2-configure-language-model-providers).
+- Check that your completions provider's per-language settings do not disable the current language (see [Posit AI Next Edit Suggestions](#posit-ai-next-edit-suggestions-nes) or [GitHub Copilot](#github-copilot)).
+- Check that [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes) does not match the current file.
+- Refer to the [Troubleshooting](assistant-troubleshooting.qmd) guide for more help.

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -59,7 +59,7 @@ To disable Posit AI NES, do any of the following:
 - Sign out of Posit AI in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects chat and other features that rely on the account.
 - Set [`nextEditSuggestions.enable`](positron://settings/nextEditSuggestions.enable) to `{ "*": false }` to disable Posit AI NES everywhere. To disable only some languages, set those entries to `false`.
 
-To exclude specific files from Posit AI NES regardless of language, use the shared [`aiExcludes`](#shared-settings) setting.
+To exclude specific files from Posit AI NES regardless of language, [use the shared `aiExcludes` setting](#shared-settings).
 
 ## GitHub Copilot
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -60,7 +60,7 @@ Posit AI is enabled by default. Set [`positron.assistant.provider.positAI.enable
 
 ### Add Posit AI as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Posit AI** as the model provider.
 1. Select the **Sign in** button to initiate Posit AI's OAuth authentication flow.
     - Complete the authentication flow in your browser, and return to Positron when finished.

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -52,13 +52,13 @@ Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenA
 
 ## Posit AI
 
-Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
-
-### Enable Posit AI as a provider
-
 ::: {.callout-important}
 Posit AI requires a Posit account and sign-in before it can be used. Visit [posit.ai](https://posit.ai/) to learn more and create an account.
 :::
+
+Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
+
+### Enable Posit AI as a provider
 
 Posit AI is enabled by default. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -46,7 +46,7 @@ Please ensure you consult your provider's privacy policy for information on the 
 
 ## Step 2: Configure language model providers
 
-Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenAI are enabled by default. Other providers are in preview or experimental status and must be enabled through settings.
+Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenAI are enabled by default but are not active until you sign in. Other providers are in preview or experimental status and must be enabled through settings.
 
 ::: {.panel-tabset group="providers"}
 
@@ -57,10 +57,6 @@ Posit AI requires an account — visit [posit.ai](https://posit.ai/) to learn mo
 :::
 
 Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
-
-### Enable Posit AI as a provider
-
-Posit AI is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
 
 ### Add Posit AI as a language model provider
 
@@ -90,10 +86,6 @@ To use Anthropic's Claude models in Positron Assistant, you need to bring your o
 </details>
 :::
 
-### Enable Anthropic as a provider
-
-Anthropic is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.anthropic.enable`](positron://settings/positron.assistant.provider.anthropic.enable) to `false` to disable it.
-
 ### Add Anthropic as a language model provider
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
@@ -118,10 +110,6 @@ Students and faculty can use GitHub Copilot for free as part of the GitHub Educa
 
 </details>
 :::
-
-### Enable GitHub Copilot as a provider
-
-GitHub Copilot is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.githubCopilot.enable`](positron://settings/positron.assistant.provider.githubCopilot.enable) to `false` to disable it.
 
 ### Add GitHub Copilot as a language model provider
 
@@ -155,10 +143,6 @@ To use Amazon Bedrock in Positron Desktop, you must:
 </details>
 
 :::
-
-### Enable Amazon Bedrock as a provider
-
-Amazon Bedrock is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.amazonBedrock.enable`](positron://settings/positron.assistant.provider.amazonBedrock.enable) to `false` to disable it.
 
 <details>
 <summary>(Optional) Configure AWS region and profile</summary>
@@ -214,10 +198,6 @@ To use Snowflake Cortex in Positron Desktop, Positron Assistant requires a **Sno
 
 :::
 
-### Enable Snowflake Cortex as a provider
-
-Snowflake Cortex is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.snowflakeCortex.enable`](positron://settings/positron.assistant.provider.snowflakeCortex.enable) to `false` to disable it.
-
 ### Add Snowflake Cortex as a language model provider
 
 1. Add your `SNOWFLAKE_ACCOUNT` ID to the [`positron.assistant.providerVariables.snowflake`](positron://settings/positron.assistant.providerVariables.snowflake) setting
@@ -270,10 +250,6 @@ To use specific models instead of `model-router`, configure the [`positron.assis
 Use the model name and deployment identifier from your Foundry resource for each entry.
 
 ## OpenAI
-
-### Enable OpenAI as a provider
-
-OpenAI is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.openAI.enable`](positron://settings/positron.assistant.provider.openAI.enable) to `false` to disable it.
 
 ### Add OpenAI as a language model provider
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -56,6 +56,10 @@ Posit AI is a hosted language model service from Posit. It provides both chat mo
 
 ### Enable Posit AI as a provider
 
+::: {.callout-important}
+Posit AI requires a Posit account and sign-in before it can be used. Visit [posit.ai](https://posit.ai/) to learn more and create an account.
+:::
+
 Posit AI is enabled by default. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
 
 ### Add Posit AI as a language model provider

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -53,14 +53,14 @@ Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenA
 ## Posit AI
 
 ::: {.callout-important}
-Posit AI requires a Posit account and sign-in before it can be used. Visit [posit.ai](https://posit.ai/) to learn more and create an account.
+Posit AI requires an account — visit [posit.ai](https://posit.ai/) to learn more and create one.
 :::
 
 Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
 
 ### Enable Posit AI as a provider
 
-Posit AI is enabled by default. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
+Posit AI is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
 
 ### Add Posit AI as a language model provider
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -92,7 +92,7 @@ To use Anthropic's Claude models in Positron Assistant, you need to bring your o
 
 ### Enable Anthropic as a provider
 
-Anthropic is enabled by default. Opt out of the [`positron.assistant.provider.anthropic.enable`](positron://settings/positron.assistant.provider.anthropic.enable) setting to disable it.
+Anthropic is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.anthropic.enable`](positron://settings/positron.assistant.provider.anthropic.enable) to `false` to disable it.
 
 ### Add Anthropic as a language model provider
 
@@ -121,7 +121,7 @@ Students and faculty can use GitHub Copilot for free as part of the GitHub Educa
 
 ### Enable GitHub Copilot as a provider
 
-GitHub Copilot is enabled by default. Opt out of the [`positron.assistant.provider.githubCopilot.enable`](positron://settings/positron.assistant.provider.githubCopilot.enable) setting to disable it.
+GitHub Copilot is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.githubCopilot.enable`](positron://settings/positron.assistant.provider.githubCopilot.enable) to `false` to disable it.
 
 ### Add GitHub Copilot as a language model provider
 
@@ -158,7 +158,7 @@ To use Amazon Bedrock in Positron Desktop, you must:
 
 ### Enable Amazon Bedrock as a provider
 
-Amazon Bedrock is enabled by default. Set [`positron.assistant.provider.amazonBedrock.enable`](positron://settings/positron.assistant.provider.amazonBedrock.enable) to `false` to disable it.
+Amazon Bedrock is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.amazonBedrock.enable`](positron://settings/positron.assistant.provider.amazonBedrock.enable) to `false` to disable it.
 
 <details>
 <summary>(Optional) Configure AWS region and profile</summary>
@@ -216,7 +216,7 @@ To use Snowflake Cortex in Positron Desktop, Positron Assistant requires a **Sno
 
 ### Enable Snowflake Cortex as a provider
 
-Snowflake Cortex is enabled by default. Set [`positron.assistant.provider.snowflakeCortex.enable`](positron://settings/positron.assistant.provider.snowflakeCortex.enable) to `false` to disable it.
+Snowflake Cortex is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.snowflakeCortex.enable`](positron://settings/positron.assistant.provider.snowflakeCortex.enable) to `false` to disable it.
 
 ### Add Snowflake Cortex as a language model provider
 
@@ -273,7 +273,7 @@ Use the model name and deployment identifier from your Foundry resource for each
 
 ### Enable OpenAI as a provider
 
-OpenAI is enabled by default. Set [`positron.assistant.provider.openAI.enable`](positron://settings/positron.assistant.provider.openAI.enable) to `false` to disable it.
+OpenAI is enabled by default but is not active until you sign in. Set [`positron.assistant.provider.openAI.enable`](positron://settings/positron.assistant.provider.openAI.enable) to `false` to disable it.
 
 ### Add OpenAI as a language model provider
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -24,6 +24,7 @@ Positron Assistant supports the following language model providers:
 
 | Provider | Chat | Code Completions | Authentication |
 |------|:--:|:---:|---------|
+| Posit AI | {{< fa check >}} | {{< fa check >}} | OAuth |
 | Anthropic | {{< fa check >}} | | API Key |
 | GitHub Copilot (Preview) | {{< fa check >}} | {{< fa check >}} | GitHub OAuth |
 | Amazon Bedrock | {{< fa check >}} | | AWS CLI or Posit Workbench Managed Credentials |
@@ -45,9 +46,24 @@ Please ensure you consult your provider's privacy policy for information on the 
 
 ## Step 2: Configure language model providers
 
-Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenAI are enabled by default. Other providers are in preview or experimental status and must be enabled through settings.
+Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenAI are enabled by default. Other providers are in preview or experimental status and must be enabled through settings.
 
 ::: {.panel-tabset group="providers"}
+
+## Posit AI
+
+Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions).
+
+### Enable Posit AI as a provider
+
+Posit AI is enabled by default. Set [`positron.assistant.provider.positAI.enable`](positron://settings/positron.assistant.provider.positAI.enable) to `false` to disable it.
+
+### Add Posit AI as a language model provider
+
+1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Select **Posit AI** as the model provider.
+1. Select the **Sign in** button to initiate Posit AI's OAuth authentication flow.
+    - Complete the authentication flow in your browser, and return to Positron when finished.
 
 ## Anthropic
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -52,7 +52,7 @@ Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenA
 
 ## Posit AI
 
-Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions).
+Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
 
 ### Enable Posit AI as a provider
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -53,7 +53,7 @@ Posit AI, Anthropic, GitHub Copilot, Amazon Bedrock, Snowflake Cortex, and OpenA
 ## Posit AI
 
 ::: {.callout-important}
-Posit AI requires an account — visit [posit.ai](https://posit.ai/) to learn more and create one.
+Posit AI requires an account. Visit [posit.ai](https://posit.ai/) to learn more and create one.
 :::
 
 Posit AI is a hosted language model service from Posit. It provides both chat models and code completions in the form of [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -98,9 +98,6 @@ Anthropic is enabled by default. Opt out of the [`positron.assistant.provider.an
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **Anthropic** as the model provider.
-
-    ![Anthropic selected in provider modal](images/assistant-provider-modal-anthropic.png){width=600}
-
 1. Paste your Claude Console API key into the input box and select **Sign in**.
 
 ::: {.callout-note}
@@ -130,9 +127,6 @@ GitHub Copilot is enabled by default. Opt out of the [`positron.assistant.provid
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **GitHub Copilot** as the model provider.
-
-    ![GitHub Copilot selected in provider modal](images/assistant-provider-modal-github-copilot.png){width=600}
-
 1. Select the **Sign in** button to initiate GitHub's OAuth authentication flow.
     - Complete the authentication flow in your browser, and return to Positron when finished.
 
@@ -209,9 +203,6 @@ If no inference profile exists for your preferred region, Positron Assistant fal
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **Amazon Bedrock** as the model provider.
-
-    ![Amazon Bedrock selected in provider modal](images/assistant-provider-modal-amazon-bedrock.png){width=600}
-
 1. Select **Sign in** so Positron Assistant can verify your AWS CLI authentication.
 
 
@@ -232,9 +223,6 @@ Snowflake Cortex is enabled by default. Set [`positron.assistant.provider.snowfl
 1. Add your `SNOWFLAKE_ACCOUNT` ID to the [`positron.assistant.providerVariables.snowflake`](positron://settings/positron.assistant.providerVariables.snowflake) setting
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **Snowflake Cortex** as the model provider.
-
-    ![Snowflake Cortex selected in provider modal](images/assistant-provider-modal-snowflake-cortex.png){width=600}
-
 1. Paste your Snowflake Cortex PAT into the API key box, then select **Sign in**.
 
 ## Microsoft Foundry
@@ -256,9 +244,6 @@ Microsoft Foundry provider support is in preview. Opt in to the [`positron.assis
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **Microsoft Foundry** as the model provider.
-
-    ![Microsoft Foundry selected in provider modal](images/assistant-provider-modal-microsoft-foundry.png){fig-alt="Configure Language Model Providers modal with Microsoft Foundry selected, showing API Key and Base URL fields." width=600}
-
 1. Enter your Foundry endpoint URL in the **Base URL** field and your API key in the **API Key** field, then select **Sign in**.
 
 ::: {.callout-note}
@@ -294,9 +279,6 @@ OpenAI is enabled by default. Set [`positron.assistant.provider.openAI.enable`](
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **OpenAI** as the model provider.
-
-    ![OpenAI selected in provider modal](images/assistant-provider-modal-openai.png){width=600}
-
 1. Paste your OpenAI API key into the input box and select **Sign in**.
 
 ::: {.callout-note}
@@ -323,9 +305,6 @@ Custom provider support is experimental. Opt in to the [`positron.assistant.prov
 
 1. Run the command _Positron Assistant: Configure Language Model Providers_
 1. Select **Custom Provider** as the model provider.
-
-    ![Custom Provider selected in provider modal](images/assistant-provider-modal-custom-provider.png){width=600}
-
 1. Enter your API key and base URL into the input boxes and select **Sign in**.
 
 ::: {.callout-note}


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/13335

- adds Posit AI to getting started page https://deploy-preview-371--positron-posit-co.netlify.app/assistant-getting-started.html
- adds Posit AI NES docs to completions page https://deploy-preview-371--positron-posit-co.netlify.app/assistant-completions.html