### PR TITLE
Assistant: landing page updates for Posit Assistant

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -102,7 +102,7 @@ website:
             - help-pane.qmd
         - section: "AI Tools"
           contents:
-            - section: "Positron Assistant"
+            - section: "Assistant"
               href: assistant.qmd
               contents:
               - text: "Overview"

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -101,7 +101,7 @@ website:
             - help-pane.qmd
         - section: "AI Tools"
           contents:
-            - section: "Positron Assistant"
+            - section: "Assistant"
               href: assistant.qmd
               contents:
               - text: "Overview"

--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -33,7 +33,7 @@ To open the chat pane, click the chat robot icon in the sidebar or run the comma
 Inline chat is a mini chat interface that can be opened directly within your code Editor, Notebook, or Terminal. It allows you to ask questions, get suggestions, and apply changes without leaving your current context.
 
 ::: {.callout-note}
-Inline chat is only available through Positron Assistant. It is not currently supported by [Posit Assistant](https://pos.it/assistant).
+Inline chat is only available in Positron Assistant. [Posit Assistant](https://pos.it/assistant) does not currently support inline chat.
 :::
 
 ::: {.panel-tabset group="inline-chat-area"}

--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -32,7 +32,7 @@ To open the chat pane, click the chat robot icon in the sidebar or run the comma
 
 Inline chat is a mini chat interface that can be opened directly within your code Editor, Notebook, or Terminal. It allows you to ask questions, get suggestions, and apply changes without leaving your current context.
 
-::: {.callout-note}
+::: {.callout-important}
 Inline chat is only available in Positron Assistant. [Posit Assistant](https://pos.it/assistant) does not currently support inline chat.
 :::
 

--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -32,6 +32,10 @@ To open the chat pane, click the chat robot icon in the sidebar or run the comma
 
 Inline chat is a mini chat interface that can be opened directly within your code Editor, Notebook, or Terminal. It allows you to ask questions, get suggestions, and apply changes without leaving your current context.
 
+::: {.callout-note}
+Inline chat is only available through Positron Assistant. It is not currently supported by [Posit Assistant](https://pos.it/assistant).
+:::
+
 ::: {.panel-tabset group="inline-chat-area"}
 
 ## Editor or notebook

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -76,7 +76,7 @@ Anthropic is enabled by default. Opt out of the [`positron.assistant.provider.an
 
 ### Add Anthropic as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Anthropic** as the model provider.
 
     ![Anthropic selected in provider modal](images/assistant-provider-modal-anthropic.png){width=600}
@@ -108,7 +108,7 @@ GitHub Copilot is enabled by default. Opt out of the [`positron.assistant.provid
 
 ### Add GitHub Copilot as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **GitHub Copilot** as the model provider.
 
     ![GitHub Copilot selected in provider modal](images/assistant-provider-modal-github-copilot.png){width=600}
@@ -187,7 +187,7 @@ If no inference profile exists for your preferred region, Positron Assistant fal
 
 ### Add Amazon Bedrock as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Amazon Bedrock** as the model provider.
 
     ![Amazon Bedrock selected in provider modal](images/assistant-provider-modal-amazon-bedrock.png){width=600}
@@ -210,7 +210,7 @@ Snowflake Cortex is enabled by default. Set [`positron.assistant.provider.snowfl
 ### Add Snowflake Cortex as a language model provider
 
 1. Add your `SNOWFLAKE_ACCOUNT` ID to the [`positron.assistant.providerVariables.snowflake`](positron://settings/positron.assistant.providerVariables.snowflake) setting
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Snowflake Cortex** as the model provider.
 
     ![Snowflake Cortex selected in provider modal](images/assistant-provider-modal-snowflake-cortex.png){width=600}
@@ -234,7 +234,7 @@ Microsoft Foundry provider support is in preview. Opt in to the [`positron.assis
 
 ### Add Microsoft Foundry as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Microsoft Foundry** as the model provider.
 
     ![Microsoft Foundry selected in provider modal](images/assistant-provider-modal-microsoft-foundry.png){fig-alt="Configure Language Model Providers modal with Microsoft Foundry selected, showing API Key and Base URL fields." width=600}
@@ -272,7 +272,7 @@ OpenAI is enabled by default. Set [`positron.assistant.provider.openAI.enable`](
 
 ### Add OpenAI as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **OpenAI** as the model provider.
 
     ![OpenAI selected in provider modal](images/assistant-provider-modal-openai.png){width=600}
@@ -301,7 +301,7 @@ Custom provider support is experimental. Opt in to the [`positron.assistant.prov
 
 ### Add Custom Provider as a language model provider
 
-1. Run the command _Positron Assistant: Configure Language Model Providers_
+1. Run the command _Authentication: Configure Language Model Providers_
 1. Select **Custom Provider** as the model provider.
 
     ![Custom Provider selected in provider modal](images/assistant-provider-modal-custom-provider.png){width=600}

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -1,64 +1,34 @@
 ---
-title: "Positron Assistant"
-description: "Positron Assistant is an AI coding assistant built for data science. Get chat support, inline assistance, and code completions with context from your data, plots, and console history."
-listing:
-  - id: chat-features
-    type: custom
-    template: templates/welcome-card.ejs
-    contents:
-      - title: "Chat pane"
-        description: "A dedicated AI chat pane for coding, troubleshooting, and planning."
-        icon: "bi-chat-text"
-        link: "assistant-chat.qmd#chat-pane"
-      - title: "Inline chat"
-        description: "In-context AI assistance within your code Editor, Notebook, or Terminal."
-        icon: "bi-chat-square-text"
-        link: "assistant-chat.qmd#inline-chat"
-      - title: "Code completions"
-        description: "Receive code suggestions directly in your Editor or Notebook."
-        icon: "bi-code"
-        link: "assistant-completions.qmd"
-  - id: learn-more
-    type: custom
-    template: templates/welcome-card.ejs
-    contents:
-      - title: "Tips & Glossary"
-        description: "Check out tips for using Positron Assistant effectively, along with a glossary of common terms."
-        icon: "bi-lightbulb"
-        link: "assistant-tips.qmd"
-      - title: "Troubleshooting & Feedback"
-        description: "Find solutions to common issues and share feedback to help improve Positron Assistant."
-        icon: "bi-tools"
-        link: "assistant-troubleshooting.qmd"
-      - title: "Posit AI Newsletter"
-        description: "Stay on top of important AI developments at Posit and beyond with curated updates."
-        icon: "bi-journal-text"
-        link: "https://posit.co/blog/?post_tag=ai-newsletter"
+title: "Posit Assistant"
+description: "Posit Assistant is the new AI coding experience in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience built for data science."
 ---
 
 ::: {.callout-note}
-## Looking for Posit Assistant?
+## Looking for Positron Assistant?
 
-[Posit Assistant](https://pos.it/assistant) is a new AI coding experience currently available as a preview feature. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience. To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://pos.it/assistant-docs).
+Positron Assistant and Databot are being superseded by Posit Assistant and will be deprecated in a future release. Posit Assistant will move to general availability in Q3-2026.
 :::
 
-Positron Assistant is an AI coding assistant built specifically for data science workflows. It is available in **preview** starting from Positron 2025.07.0-204.
+[Posit Assistant](https://pos.it/assistant) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.
 
-Beyond your active files, selected code, and project structure, Positron Assistant is provided with context about your interactive data science work, such as your loaded data, plots, and console history, enabling more relevant guidance for exploratory analysis and modeling.
+Beyond your active files, selected code, and project structure, Posit Assistant is provided with context about your interactive data science work, such as your loaded data, plots, and console history, enabling more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
 
-::: {.callout-note}
-To get started with Positron Assistant, check out the [Getting Started](assistant-getting-started.qmd) guide.
-:::
+To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://pos.it/assistant-docs).
 
 ## Features
 
-::: {#chat-features}
-:::
+Posit Assistant has a rich set of features with the highlights listed below.
 
-## Learn more
-
-::: {#learn-more}
-:::
+| Feature | Summary |
+| --- | --- |
+| [Commands](https://posit-dev.github.io/assistant/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions — for example, `/plan`, `/new`, and `/savememory`. |
+| [Skills](https://posit-dev.github.io/assistant/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Includes built-ins like `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
+| [Memory](https://posit-dev.github.io/assistant/docs/features/memory/) | Persistent project context via an `AGENTS.md` file loaded automatically at the start of every conversation, capturing conventions, architecture, and preferences. Only loaded in trusted workspaces. |
+| [Conversations](https://posit-dev.github.io/assistant/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion, plus tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
+| [Plan Mode](https://posit-dev.github.io/assistant/docs/features/plan-mode/) | A collaborative design phase where the assistant explores the codebase, asks questions, and writes a plan file before changing code. Best for multi-step features, refactors, and unfamiliar codebases. |
+| [Chat Features](https://posit-dev.github.io/assistant/docs/features/chat-features/) | File attachments (drag-and-drop, clipboard paste, or paperclip, with `@` mentions to reference workspace files), adjustable thinking effort (Off/Low/Medium/High), and optional web search. |
+| [Context Management](https://posit-dev.github.io/assistant/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python, a token counter with detailed breakdown, and auto/manual/micro-compaction to keep long conversations within the model's context window. |
+| [Permissions & Trust](https://posit-dev.github.io/assistant/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted), per-tool permissions configurable in settings, workspace trust prompts when opening projects with `AGENTS.md`, and an optional sandbox mode for bash execution. |
 
 ## Support and terms of service
 
@@ -70,7 +40,7 @@ The Positron AI tools are "BYO-key," meaning that the tools can interact with a 
 
 ### Data collection and privacy
 
-Positron provides local software as a client to the user's selected model provider. As a result, Posit does not track, collect, or store your prompts, code, or conversations when using AI features within Positron (i.e., Positron Assistant, Databot, etc.). These features operate by communicating directly from your client software to your chosen AI model provider. Posit does not receive any AI traffic from your client's software and nor does Posit ever access or store your data. 
+Positron provides local software as a client to the user's selected model provider. As a result, Posit does not track, collect, or store your prompts, code, or conversations when using AI features within Positron (i.e., Positron Assistant, Databot, etc.). These features operate by communicating directly from your client software to your chosen AI model provider. Posit does not receive any AI traffic from your client's software and nor does Posit ever access or store your data.
 
 If you voluntarily share diagnostic logs or information with Posit for troubleshooting purposes, that shared information will be handled in accordance with [[Posit's privacy policy](privacy.qmd)]{.content-visible when-profile="positron"}[[Posit's privacy policy](https://posit.co/about/privacy-policy/)]{.content-visible when-profile="workbench"}.
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -1,6 +1,23 @@
 ---
 title: "Posit Assistant"
 description: "Posit Assistant is the new AI coding experience in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience built for data science."
+listing:
+  - id: learn-more
+    type: custom
+    template: templates/welcome-card.ejs
+    contents:
+      - title: "Get Started"
+        description: "Set up Posit Assistant and learn the essentials for your first conversation."
+        icon: "bi-rocket-takeoff"
+        link: "https://pos.it/assistant-docs"
+      - title: "Posit Assistant vs. Positron Assistant"
+        description: "Watch a walkthrough comparing Posit Assistant and Positron Assistant."
+        icon: "bi-play-circle"
+        link: "https://www.youtube.com/watch?v=Y9P2nlFXKnQ"
+      - title: "AI at Posit"
+        description: "Explore Posit's broader work on artificial intelligence for data science."
+        icon: "bi-journal-text"
+        link: "https://opensource.posit.co/topics/artificial-intelligence/"
 ---
 
 ::: {.callout-note}
@@ -29,6 +46,11 @@ Posit Assistant has a rich set of features with the highlights listed below.
 | [Chat Features](https://posit-dev.github.io/assistant/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off/Low/Medium/High) and optional web search. |
 | [Context Management](https://posit-dev.github.io/assistant/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto/manual/micro-compaction to keep long conversations within the model's context window. |
 | [Permissions & Trust](https://posit-dev.github.io/assistant/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted) and per-tool permissions configurable in settings. Includes workspace trust prompts when opening projects with `AGENTS.md` and an optional sandbox mode for bash execution. |
+
+## Learn more
+
+::: {#learn-more}
+:::
 
 ## Support and terms of service
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -32,7 +32,7 @@ Posit Assistant has a rich set of features with the highlights listed below.
 
 ## Support and terms of service
 
-Posit does not provide support or assistance for any code written or generated in Positron, with or without Positron Assistant via any model provider. Posit does not support the Anthropic or GitHub Copilot output, or test the logic used by either to generate code from prompts. Consult your AI model provider's [documentation](assistant-provider-info.qmd) for more information.
+Posit does not provide support or assistance for any code written or generated in Positron, with or without Posit Assistant, Positron Assistant, or Databot via any model provider. Posit does not support the Anthropic or GitHub Copilot output, or test the logic used by either to generate code from prompts. Consult your AI model provider's [documentation](assistant-provider-info.qmd) for more information.
 
 ### Positron AI agents
 
@@ -40,7 +40,7 @@ The Positron AI tools are "BYO-key," meaning that the tools can interact with a 
 
 ### Data collection and privacy
 
-Positron provides local software as a client to the user's selected model provider. As a result, Posit does not track, collect, or store your prompts, code, or conversations when using AI features within Positron (i.e., Positron Assistant, Databot, etc.). These features operate by communicating directly from your client software to your chosen AI model provider. Posit does not receive any AI traffic from your client's software and nor does Posit ever access or store your data.
+Positron provides local software as a client to the user's selected model provider. As a result, Posit does not track, collect, or store your prompts, code, or conversations when using AI features within Positron (i.e., Posit Assistant, Positron Assistant, Databot, etc.). These features operate by communicating directly from your client software to your chosen AI model provider. Posit does not receive any AI traffic from your client's software and nor does Posit ever access or store your data.
 
 If you voluntarily share diagnostic logs or information with Posit for troubleshooting purposes, that shared information will be handled in accordance with [[Posit's privacy policy](privacy.qmd)]{.content-visible when-profile="positron"}[[Posit's privacy policy](https://posit.co/about/privacy-policy/)]{.content-visible when-profile="workbench"}.
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -6,12 +6,12 @@ description: "Posit Assistant is the new AI coding experience in Positron, bring
 ::: {.callout-note}
 ## Looking for Positron Assistant?
 
-Positron Assistant and Databot are being superseded by Posit Assistant and will be deprecated in a future release. Posit Assistant will move to general availability in Q3-2026.
+Positron Assistant and Databot are being superseded by Posit Assistant and will be deprecated in a future release. Posit Assistant will move to general availability in Q3 2026.
 :::
 
 [Posit Assistant](https://pos.it/assistant) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.
 
-Beyond your active files, selected code, and project structure, Posit Assistant is provided with context about your interactive data science work, such as your loaded data, plots, and console history, enabling more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
+Beyond your active files, selected code, and project structure, Posit Assistant uses context from your interactive data science work, such as your loaded data, plots, and console history. This enables more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
 
 To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://pos.it/assistant-docs).
 
@@ -22,13 +22,13 @@ Posit Assistant has a rich set of features with the highlights listed below.
 | Feature | Summary |
 | --- | --- |
 | [Commands](https://posit-dev.github.io/assistant/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions — for example, `/plan`, `/new`, and `/savememory`. |
-| [Skills](https://posit-dev.github.io/assistant/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Includes built-ins like `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
-| [Memory](https://posit-dev.github.io/assistant/docs/features/memory/) | Persistent project context via an `AGENTS.md` file loaded automatically at the start of every conversation, capturing conventions, architecture, and preferences. Only loaded in trusted workspaces. |
-| [Conversations](https://posit-dev.github.io/assistant/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion, plus tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
+| [Skills](https://posit-dev.github.io/assistant/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Built-ins include `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
+| [Memory](https://posit-dev.github.io/assistant/docs/features/memory/) | Persistent project context via an `AGENTS.md` file that captures conventions, architecture, and preferences. The file loads automatically at the start of every conversation in trusted workspaces. |
+| [Conversations](https://posit-dev.github.io/assistant/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion. Includes tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
 | [Plan Mode](https://posit-dev.github.io/assistant/docs/features/plan-mode/) | A collaborative design phase where the assistant explores the codebase, asks questions, and writes a plan file before changing code. Best for multi-step features, refactors, and unfamiliar codebases. |
-| [Chat Features](https://posit-dev.github.io/assistant/docs/features/chat-features/) | File attachments (drag-and-drop, clipboard paste, or paperclip, with `@` mentions to reference workspace files), adjustable thinking effort (Off/Low/Medium/High), and optional web search. |
-| [Context Management](https://posit-dev.github.io/assistant/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python, a token counter with detailed breakdown, and auto/manual/micro-compaction to keep long conversations within the model's context window. |
-| [Permissions & Trust](https://posit-dev.github.io/assistant/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted), per-tool permissions configurable in settings, workspace trust prompts when opening projects with `AGENTS.md`, and an optional sandbox mode for bash execution. |
+| [Chat Features](https://posit-dev.github.io/assistant/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off/Low/Medium/High) and optional web search. |
+| [Context Management](https://posit-dev.github.io/assistant/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto/manual/micro-compaction to keep long conversations within the model's context window. |
+| [Permissions & Trust](https://posit-dev.github.io/assistant/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted) and per-tool permissions configurable in settings. Includes workspace trust prompts when opening projects with `AGENTS.md` and an optional sandbox mode for bash execution. |
 
 ## Support and terms of service
 
@@ -47,3 +47,4 @@ If you voluntarily share diagnostic logs or information with Posit for troublesh
 However, your AI model provider (such as [Anthropic](assistant-provider-info.qmd#anthropic) or [GitHub Copilot](assistant-provider-info.qmd#github-copilot)) may store or collect data according to their own privacy policies and terms of service. Please review your [AI model provider's data practices](assistant-provider-info.qmd) for details on what information they collect and how it's used.
 
 By using an external model provider, you acknowledge that your use is subject to their Terms of Service. All external model providers are considered “Third Party Materials” as defined in the [Posit End User License Agreement](https://posit.co/about/eula/) and Posit assumes no liability or other obligations with respect thereto and, without limiting the foregoing, is not liable for any loss or damage resulting from the use or access thereof.
+


### PR DESCRIPTION
I am tackling https://github.com/posit-dev/positron/issues/13546 in a series of PRs, to avoid a giant PR with a lot of changes.

Changes in this PR:
- update assistant landing page for posit assistant
- note inline chat is only available with positron assistant
- rename `Positron Assistant: Configure Language Model Providers` --> `Authentication: Configure Language Model Providers` (Posit AI and Google Vertex PRs docs also have this updated command)
- swap out the learn more links with resources more relevant to Posit Assistant
- rename the sidebar section from "Positron Assistant" to just "Assistant"

What I'm leaving for a follow-up PR:
- sweep for "Positron Assistant" references that can be updated to "Assistant" or "Posit Assistant", wherever applicable
- provider-specific guidance (e.g. if you want to use GitHub Copilot with Posit Assistant, you need to also enable Positron Assistant)
- any other reorg/changes to make to reduce confusion about Positron Assistant vs. Posit Assistant docs on positron.posit.co
- other suggestions/feedback outside the immediate scope of this PR