### PR TITLE
Simplify "Download" button

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -33,7 +33,7 @@ From [Posit PBC](https://posit.co/), the creators of RStudio
 ### Positron unifies exploration and production work in one free, AI-assisted environment, empowering the full spectrum of data science in Python and R.
 
 ::: {.content-visible unless-profile="workbench"}
-<a href="download.qmd" class="btn btn-outline-primary">Free Download</a>
+<a href="download.qmd" class="btn btn-outline-primary">Download</a>
 <a href="features.qmd" class="btn btn-outline-primary">Explore Features</a>
 <a href="https://posit.co/positron-updates-signup/" class="btn btn-outline-primary">Get Updates</a>
 :::


### PR DESCRIPTION
Fixes https://github.com/posit-dev/positron/issues/13760 in the sense that this addresses the awkward connotations of "Free Download". We all definitely agree that this does not communicate well for our users.

It does _not_ fix the problem of us needing to show both buttons, unfortunately. We can't tell architecture from user agent or anything else in the browser, and we needed to remove our universal installer for a variety of reasons.