### PR TITLE
Change button text from 'Free Download' to 'Download'

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -33,7 +33,7 @@ From [Posit PBC](https://posit.co/), the creators of RStudio
 ### Positron unifies exploration and production work in one free, AI-assisted environment, empowering the full spectrum of data science in Python and R.
 
 ::: {.content-visible unless-profile="workbench"}
-<a href="download.qmd" class="btn btn-outline-primary">Free Download</a>
+<a href="download.qmd" class="btn btn-outline-primary">Download</a>
 <a href="features.qmd" class="btn btn-outline-primary">Explore Features</a>
 <a href="https://posit.co/positron-updates-signup/" class="btn btn-outline-primary">Get Updates</a>
 :::


### PR DESCRIPTION
Oddly, saying "Free" makes you think that Positron is freemium and/or will monetize you in other annoying ways.