### PR TITLE
Assistant: document editor.inlineSuggest.enabled setting for completions

### DIFF
--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -37,6 +37,7 @@ The following settings apply to both providers:
 
 - [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes): Files matching these patterns will not have their contents sent to AI providers for code completions or chat context.
 - [`editor.inlineSuggest.minShowDelay`](positron://settings/editor.inlineSuggest.minShowDelay): Delay in milliseconds before showing inline suggestions. For example, setting this to `500` will show suggestions half a second after typing.
+- [`editor.inlineSuggest.enabled`](positron://settings/editor.inlineSuggest.enabled): Set to `false` to turn off inline suggestions altogether, regardless of provider.
 
 ## Posit AI Next Edit Suggestions (NES)
 


### PR DESCRIPTION
This setting disables inline suggestions completely, regardless of provider.

Preview here: https://deploy-preview-386--positron-posit-co.netlify.app/assistant-completions.html#shared-settings