### PR TITLE
Improve how hero headline hyphenated compound words render

### DIFF
--- a/css/theme.scss
+++ b/css/theme.scss
@@ -460,6 +460,11 @@ a.footnote-back {
   font-weight: 600;
 }
 
+// Keep hyphenated compounds in the hero headline from breaking mid-word
+.index-section h1 .nowrap {
+  white-space: nowrap;
+}
+
 .index-section .btn {
   margin: 0.75rem;
   padding: 1rem 2rem;

--- a/index.qmd
+++ b/index.qmd
@@ -28,7 +28,7 @@ format:
 
 From [Posit PBC](https://posit.co/), the creators of RStudio
 
-# The data science IDE. Human-driven, AI-assisted.
+# The data science IDE.<br>[Human-driven,]{.nowrap} [AI-assisted.]{.nowrap}
 
 ::: {.content-visible unless-profile="workbench"}
 


### PR DESCRIPTION
A followup to https://github.com/posit-dev/positron-website/pull/384

The homepage headline ("The data science IDE. Human-driven, AI-assisted.") wrapped awkwardly at _most_ widths. Because a hyphen is a valid line-break point, the browser would split hyphenated compounds mid-word (e.g. "AI-" / "assisted"), and the break landed inconsistently.

This PR:
- Forces the line break at the sentence boundary with `<br>`, so the H1 reads as two clean lines: "The data science IDE." / "Human-driven, AI-assisted."
- Wraps "Human-driven," and "AI-assisted." in `.nowrap` spans (with a new `white-space: nowrap` rule scoped to `.index-section h1`) so those compounds never split mid-word, including when the second sentence wraps on narrow mobile screens.

The H1 sits above the profile-specific content blocks, so this applies to both the public and Workbench builds.

Here's what we'll have after this change for big screens:

<img width="1412" height="742" alt="Screenshot 2026-06-15 at 8 32 30 AM" src="https://github.com/user-attachments/assets/27b37daf-9ae6-4b70-ac8f-033f46acdb7d" />

For little screens:

<img width="429" height="702" alt="Screenshot 2026-06-15 at 8 32 42 AM" src="https://github.com/user-attachments/assets/c8f7c5f7-cd6f-4130-bf2e-804180a88d9d" />
