### PR TITLE
Document `ai.enabled` setting

### DIFF
--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -81,7 +81,7 @@ Fix and Explain inherit these options from the chat pane:
 
 ### Managing Console actions
 
-- To disable Console actions, modify the [`positron.assistant.consoleActions.enable`](positron://settings/positron.assistant.consoleActions.enable) setting.
+- To disable Console actions, set [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) to `false`.
 - To review your Fix and Explain chat history for the current chat session, run the _Chat: Open Quick Chat_ command and your chat history will appear in the Quick Chat overlay.
 
 ## Managing models

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -6,7 +6,7 @@ description: "Boost your productivity with AI code suggestions via Posit AI Next
 Code completions are text suggestions that appear inline as you type in an editor. These suggestions can be lines or blocks of code based on the context of what you're writing. Other names for code completions include inline suggestions, ghost text, or inline completions.
 
 ::: {.callout-important}
-Completions are powered by Posit AI or GitHub Copilot. Ensure you've added one or both of these as a language model provider:
+Completions are powered by Posit AI or GitHub Copilot. Ensure you have added one or both of these as a language model provider:
 
 - [Add Posit AI as a language model provider](assistant-providers.qmd#posit-ai)
 - [Add GitHub Copilot as a language model provider](assistant-providers.qmd#github-copilot)
@@ -29,7 +29,7 @@ The following commands apply to both providers:
 | Command | Description |
 | --- | --- |
 | _Snooze Inline Suggestions_ | Pause inline suggestions temporarily for a specified duration. |
-| _Cancel Snooze Inline Suggestions_ | Resume inline suggestions immediately if they have been snoozed. |
+| _Cancel Snooze Inline Suggestions_ | Resume snoozed inline suggestions immediately. |
 
 ### Settings {#shared-settings}
 
@@ -41,13 +41,13 @@ The following settings apply to both providers:
 
 ## Posit AI Next Edit Suggestions (NES)
 
-When using Posit AI as your completions provider, code completions take the form of Posit AI Next Edit Suggestions (NES), a preview feature. Rather than only suggesting text at the cursor position, Posit AI NES proposes edits anywhere in the file based on the changes you've recently made, including insertions, deletions, and modifications to existing code.
+When using Posit AI as your completions provider, code completions take the form of Posit AI Next Edit Suggestions (NES), a preview feature. Posit AI NES proposes edits anywhere in the file, not just at the cursor. It responds to your recent changes, including insertions, deletions, and modifications to existing code.
 
 Posit AI NES suggestions appear inline in the editor. You can accept, navigate, or dismiss them using the same keybindings as other code completions.
 
 ### Enable
 
-Posit AI NES is enabled by default once you've [signed in to the Posit AI provider](assistant-providers.qmd#posit-ai). No additional setting changes are required.
+Posit AI NES is enabled by default once you have [signed in to the Posit AI provider](assistant-providers.qmd#posit-ai). No additional setting changes are required.
 
 ### Restrict to specific languages
 
@@ -68,7 +68,7 @@ When using GitHub Copilot as your completions provider, code completions appear 
 
 ### Enable
 
-GitHub Copilot completions are enabled by default once you've [signed in to the GitHub Copilot provider](assistant-providers.qmd#github-copilot). No additional setting changes are required.
+GitHub Copilot completions are enabled by default once you have [signed in to the GitHub Copilot provider](assistant-providers.qmd#github-copilot). No additional setting changes are required.
 
 ### Restrict to specific languages
 
@@ -89,7 +89,7 @@ To exclude specific files from Copilot completions regardless of language, use t
 
 The Assistant status bar icon indicates the current state of GitHub Copilot completions.
 
-![Assistant status bar icon](images/assistant-status-bar-icon.png){width=750}
+![Assistant status bar icon](images/assistant-status-bar-icon.png){fig-alt="The Assistant status bar icon in the Positron status bar, showing the current state of GitHub Copilot completions." width=750}
 
 To manage Copilot completions using the status bar icon:
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -39,7 +39,7 @@ The following settings apply to both providers:
 - [`editor.inlineSuggest.minShowDelay`](positron://settings/editor.inlineSuggest.minShowDelay): Delay in milliseconds before showing inline suggestions. For example, setting this to `500` will show suggestions half a second after typing.
 - [`editor.inlineSuggest.enabled`](positron://settings/editor.inlineSuggest.enabled): Set to `false` to turn off inline suggestions altogether, regardless of provider.
 
-## Posit AI Next Edit Suggestions (NES)
+## Posit AI Next Edit Suggestions (NES) {#posit-ai-nes}
 
 When using Posit AI as your completions provider, code completions take the form of Posit AI Next Edit Suggestions (NES), a preview feature. Posit AI NES proposes edits anywhere in the file, not just at the cursor. It responds to your recent changes, including insertions, deletions, and modifications to existing code.
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -51,14 +51,14 @@ Posit AI NES is enabled by default once you have [signed in to the Posit AI prov
 
 ### Restrict to specific languages
 
-Posit AI NES skips `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`nextEditSuggestions.enable`](positron://settings/nextEditSuggestions.enable) setting to change which languages Posit AI NES applies to.
+Posit AI NES skips `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) setting to change which languages Posit AI NES applies to.
 
 ### Disable
 
 To disable Posit AI NES, do any of the following:
 
 - Sign out of Posit AI in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects chat and other features that rely on the account.
-- Set [`nextEditSuggestions.enable`](positron://settings/nextEditSuggestions.enable) to `{ "*": false }` to disable Posit AI NES everywhere. To disable only some languages, set those entries to `false`.
+- Set [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) to `{ "*": false }` to disable Posit AI NES everywhere. To disable only some languages, set those entries to `false`.
 
 To exclude specific files from Posit AI NES regardless of language, [use the shared `aiExcludes` setting](#shared-settings).
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -100,6 +100,7 @@ To manage Copilot completions using the status bar icon:
 
 If you are not receiving suggestions:
 
+- Check that [`ai.enabled`](positron://settings/ai.enabled) is not set to `false`. When it is, Positron disables all AI features including code completions, regardless of other settings.
 - Confirm you are signed in to your completions provider in the [language model provider configuration](assistant-getting-started.qmd#configure-a-language-model-provider).
 - Check that your completions provider's per-language settings do not disable the current language (see [Posit AI Next Edit Suggestions](#posit-ai-next-edit-suggestions-nes) or [GitHub Copilot](#github-copilot)).
 - Check that [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes) does not match the current file.

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -24,7 +24,7 @@ To use AI in Positron, first configure a language model provider, then start usi
 
 ## Step 1: Configure a language model provider {#configure-a-language-model-provider}
 
-All providers are enabled by default and appear in the provider list, but none are active unless you are authenticated with the provider.
+Positron enables all providers by default and they appear in the provider list, but none are active unless you authenticate with the provider.
 
 To connect a provider, run the command _Authentication: Configure Language Model Providers_, select the provider, and authenticate. For account requirements, authentication details, and any settings to configure first, see the [Language Model Providers](assistant-providers.qmd) reference.
 
@@ -34,15 +34,15 @@ To connect a provider, run the command _Authentication: Configure Language Model
 | [Amazon Bedrock](assistant-providers.qmd#amazon-bedrock) | {{< fa check >}} | | AWS CLI or Posit Workbench Managed Credentials |
 | [Anthropic](assistant-providers.qmd#anthropic) | {{< fa check >}} | | API Key |
 | [OpenAI](assistant-providers.qmd#openai) | {{< fa check >}} | | API Key |
-| [Snowflake Cortex](assistant-providers.qmd#snowflake-cortex) | {{< fa check >}} | | API Key or Posit Workbench Managed Credentials |
+| [Snowflake Cortex](assistant-providers.qmd#snowflake-cortex) | {{< fa check >}} | | API Key or Workbench Managed Credentials |
 | [GitHub Copilot](assistant-providers.qmd#github-copilot) [Preview]{.provider-badge .preview} | {{< fa check >}} | {{< fa check >}} | OAuth |
-| [Microsoft Foundry](assistant-providers.qmd#microsoft-foundry) [Preview]{.provider-badge .preview} | {{< fa check >}} | | API Key or Posit Workbench Managed Credentials |
+| [Microsoft Foundry](assistant-providers.qmd#microsoft-foundry) [Preview]{.provider-badge .preview} | {{< fa check >}} | | API Key or Workbench Managed Credentials |
 | [Custom Provider](assistant-providers.qmd#custom-provider) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [DeepSeek](assistant-providers.qmd#deepseek) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [Gemini Code Assist](assistant-providers.qmd#gemini-code-assist) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [Google Vertex AI](assistant-providers.qmd#google-vertex-ai) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | Google Cloud CLI or Service Account Credentials |
 
-Please ensure you consult your provider's privacy policy for information on the data they collect and how it is used. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.
+Please ensure you consult your provider's privacy policy for information on the data they collect and how they use it. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.
 
 {{< include _privacy-link.qmd >}}
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -63,4 +63,4 @@ To turn off all Positron AI features, set [`ai.enabled`](positron://settings/ai.
 - Posit AI Next Edit Suggestions (NES)
 - Notebook AI features (Fix, Explain, ghost cells, ask assistant)
 - Console Fix & Explain
-- GitHub Copilot
+- GitHub Copilot (Chat, Completions)

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -61,13 +61,15 @@ To turn off all Positron AI features at once, set [`ai.enabled`](positron://sett
 
 - Posit Assistant
 - Posit AI Next Edit Suggestions (NES)
-- Notebook AI features (Fix, Explain, ghost cells, ask assistant)
+- Notebook AI features
 - Console Fix & Explain
 - GitHub Copilot (Chat, Completions)
 
 To disable a specific feature without affecting others:
 
-- **Posit Assistant:** set [`assistant.enabled`](positron://settings/assistant.enabled) to `false` to hide the sidebar icon and make its commands unavailable.
-- **Code completions:** see [Code completions](assistant-completions.qmd) (Posit AI NES and GitHub Copilot).
-- **Console Fix & Explain:** see [Console Fix & Explain](assistant-chat.qmd#managing-console-actions).
-- **Notebook AI features:** TBD pending [posit-dev/positron#13816](https://github.com/posit-dev/positron/issues/13816).
+| Setting | Features Affected |
+|---------|------------------|
+| [`assistant.enabled`](positron://settings/assistant.enabled) | [Posit Assistant](https://assistant.posit.co) (set to `false` to disable) |
+| [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) | [Posit AI NES](assistant-completions.qmd#posit-ai-nes) (set to `{ "*": false }` to disable) |
+| [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot Code Completions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable) |
+| [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) | [Console Fix & Explain](assistant-chat.qmd#managing-console-actions) (set to `false` to disable) |

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -57,10 +57,17 @@ For the full Posit Assistant configuration guide and feature documentation, see 
 
 ## Disable AI features {#disable-ai-features}
 
-To turn off all Positron AI features, set [`ai.enabled`](positron://settings/ai.enabled) to `false`. This overrides individual feature settings and disables:
+To turn off all Positron AI features at once, set [`ai.enabled`](positron://settings/ai.enabled) to `false`. This overrides individual feature settings and disables:
 
 - Posit Assistant
 - Posit AI Next Edit Suggestions (NES)
 - Notebook AI features (Fix, Explain, ghost cells, ask assistant)
 - Console Fix & Explain
 - GitHub Copilot (Chat, Completions)
+
+To disable a specific feature without affecting others:
+
+- **Posit Assistant:** set [`assistant.enabled`](positron://settings/assistant.enabled) to `false` to hide the sidebar icon and make its commands unavailable.
+- **Code completions:** see [Code completions](assistant-completions.qmd) (Posit AI NES and GitHub Copilot).
+- **Console Fix & Explain:** see [Console Fix & Explain](assistant-chat.qmd#managing-console-actions).
+- **Notebook AI features:** TBD pending [posit-dev/positron#13816](https://github.com/posit-dev/positron/issues/13816).

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -54,3 +54,13 @@ For the full Posit Assistant configuration guide and feature documentation, see 
 
 ::: {#ai-features}
 :::
+
+## Disable AI features {#disable-ai-features}
+
+To turn off all Positron AI features, set [`ai.enabled`](positron://settings/ai.enabled) to `false`. This overrides individual feature settings and disables:
+
+- Posit Assistant
+- Posit AI Next Edit Suggestions (NES)
+- Notebook AI features (Fix, Explain, ghost cells, ask assistant)
+- Console Fix & Explain
+- GitHub Copilot


### PR DESCRIPTION
Documentation for https://github.com/posit-dev/positron/issues/14356.

Closes https://github.com/posit-dev/positron/issues/14217.

See https://github.com/posit-dev/positron/pull/14447 for the underlying implementation.

I also applied some doc-reviewer fixes, which increased the size of the diff. I'll comment inline where the actual net new docs are.