### PR TITLE
Add a new GH action to publish release note assets to the CDN

### DIFF
--- a/.claude/skills/prepare-release-notes/SKILL.md
+++ b/.claude/skills/prepare-release-notes/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: prepare-release-notes
+description: Guides authoring the in-product release notes in release-notes/next.md, especially adding and iterating on images/GIFs with a local in-product preview loop before committing the asset to release-notes/assets/. Use when writing or revising next.md ahead of a release or patch (typically invoked as /prepare-release-notes). The later ship-day promotion of next.md into release.md is handled by /release-update and /patch-update, not this skill.
+---
+
+# Prepare release notes
+
+This skill covers **authoring** `release-notes/next.md`: the content that ships to S3 as the in-product release notes during the release cycle. It is the most painful part of the job when images are involved, because you usually have to iterate on a GIF or screenshot a few times to get it to look right, and previewing an image that is not yet on the CDN takes a specific trick.
+
+By the time `next.md` is promoted into `release.md` on ship day (`/release-update` or `/patch-update`), it should already be final and reviewed. So do the real work here.
+
+This skill is a guided checklist. Drive the mechanical edits; pause for user input where noted with ⏸.
+
+## 1. Where content goes
+
+All authoring happens in `release-notes/next.md`. Use `release-notes/release-notes-template.md` as the shape of the empty state: a `### Highlights` list, the `<div id="checkbox"></div>` marker, and a `### Changelog` with `#### New features`, `#### Bug fixes`, and `#### Dependencies`. Look at the most recent `release-notes/release-*.qmd` for tone and the level of detail in highlights.
+
+## 2. Adding and iterating on images (the painful part)
+
+Images are referenced with an **absolute CDN URL**, not a relative path:
+
+```html
+<p align="center"><img src="https://cdn.posit.co/positron/releases/release-notes/assets/2026-06-posit-assistant.gif" alt="Describe the image"></p>
+```
+
+But during authoring that URL does not resolve yet, because the asset is not on the CDN. To see how it actually renders inside Positron, use the in-product preview loop below.
+
+### a. Preview an unpublished image in-product
+
+Positron has a _Developer: Open Current File as Release Notes_ command that renders a file as release notes. To make an unpublished image show up in that webview:
+
+1. Put the image file **in the same directory as the file you are previewing**, i.e. directly in `release-notes/` next to `next.md` (not in a subdirectory).
+2. Reference it by a **bare relative filename** while iterating:
+   ```html
+   <p align="center"><img src="2026-06-posit-assistant.gif" alt="Describe the image"></p>
+   ```
+3. Run _Developer: Open Current File as Release Notes_ on `next.md`.
+4. Tweak the asset, re-export, overwrite the file, and re-run the command. Repeat until it looks right.
+
+**Why a bare filename in the same directory, and why not other approaches** (empirical, from Positron's `releaseNotesEditor.ts`):
+
+- The webview content security policy is `img-src https: data:;`.
+- For the current file, the webview's allowed root is the file's own directory and the `<base href>` points there, so a bare relative filename resolves to an `https`-scheme webview resource and satisfies the CSP.
+- Paths that leave that single directory were observed to be blocked: subdirectory paths like `assets/...` or `images/...`, parent paths like `../images/...`, and absolute file paths. That is why the iteration copy lives directly in `release-notes/`, even though its permanent home is `release-notes/assets/`.
+- `http://localhost` fails (not `https`). Large `data:` URIs failed in practice (sanitizer/size), even though `data:` is allowed by the CSP.
+
+### b. Centering
+
+Wrap the image in `<p align="center">...</p>` so it centers in both the in-product webview and the published site. Do **not** use inline `style="..."`: the webview CSP blocks inline styles, so CSS centering will not render in-product. The `align` attribute is on the sanitizer's allow-list and is honored directly by the browser, so it works in both places and is safe to keep in the shipped markup.
+
+## 3. Before you commit (checklist)
+
+Once the image looks right, convert the temporary preview reference into the committed form:
+
+1. ⏸ **Move the asset into `release-notes/assets/`** with its final name, `<year>-<month>-<slug>.<ext>` (e.g. `release-notes/assets/2026-06-posit-assistant.gif`). Do not leave the iteration copy loose in `release-notes/`.
+2. **Restore the `<img src>` to the absolute CDN URL** (`https://cdn.posit.co/positron/releases/release-notes/assets/<name>`), keeping the `<p align="center">` wrapper.
+3. Confirm no stray bare-filename references or temporary image copies remain in `release-notes/` (only `next.md`, the archived `release-*.qmd`, the template, and the `assets/` directory should be there).
+4. Check `git status`: the new asset under `release-notes/assets/` and the edits to `next.md` should be the only changes.
+
+## 4. How the asset reaches the CDN
+
+You do not upload assets by hand. When a change under `release-notes/assets/` merges to `main`, the `publish-release-notes-assets.yml` workflow syncs the directory to S3 and invalidates CloudFront (additive sync, never deletes). See `release-notes/assets/README.md`.
+
+This means you can also work in two steps if you want to preview the *real* CDN rendering rather than the in-product approximation: merge an assets-only change first so the file goes live on the CDN, then author `next.md` against the live URL. Either order is fine.

--- a/.github/workflows/publish-release-notes-assets.yml
+++ b/.github/workflows/publish-release-notes-assets.yml
@@ -1,0 +1,63 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'release-notes/assets/**'
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: 'Release channel to publish to (e.g., "releases", "dailies", "staging")'
+        options:
+          - dailies
+          - staging
+          - releases
+        default: releases
+        required: true
+        type: choice
+
+name: Publish Release Notes Assets
+
+# Avoid concurrent runs racing to sync the same prefix; let the latest win.
+concurrency:
+  group: publish-release-notes-assets
+  cancel-in-progress: false
+
+jobs:
+  s3-release-notes-assets:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials for S3
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_RW_ROLE }}
+          aws-region: us-east-1
+
+      - name: Sync release notes assets to S3
+        run: |
+          CHANNEL="${{ inputs.release_channel || 'releases' }}"
+          S3_PREFIX="s3://posit-positron-downloads/positron/${CHANNEL}/release-notes/assets"
+          # Additive sync: uploads new or changed files only, never deletes existing
+          # assets (no --delete), so re-running is safe and idempotent.
+          aws s3 sync "${GITHUB_WORKSPACE}/release-notes/assets/" "${S3_PREFIX}/" \
+            --no-progress \
+            --exclude "README.md"
+
+      - name: Configure AWS Credentials for CloudFront
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CDN_RW_ROLE }}
+          aws-region: us-east-1
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          CHANNEL="${{ inputs.release_channel || 'releases' }}"
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} \
+            --paths "/positron/${CHANNEL}/release-notes/assets/*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,8 @@ Key formatting rules:
 - **Netlify**: Auto-deploys from main branch using `@quarto/netlify-plugin-quarto`
 - **GitHub Actions**:
   - `lint.yml`: URL checking on PRs
-  - `publish-release-notes.yml`: Manual workflow for S3/CloudFront deployment
+  - `publish-release-notes.yml`: Manual workflow for S3/CloudFront deployment of the release notes markdown
+  - `publish-release-notes-assets.yml`: Syncs `release-notes/assets/` (images, GIFs) to S3/CloudFront. Runs automatically when assets change on `main`, plus manual dispatch. See `release-notes/assets/README.md`.
 
 ## Videos and Git LFS
 

--- a/release-notes/assets/README.md
+++ b/release-notes/assets/README.md
@@ -1,0 +1,31 @@
+# Release notes assets
+
+Images and GIFs referenced from the release notes (`release.md` and the archived
+`release-*.qmd` files) live here so they are version-controlled alongside the
+notes that use them.
+
+## How these reach the CDN
+
+When a change under `release-notes/assets/` is merged to `main`, the
+[`publish-release-notes-assets.yml`](../../.github/workflows/publish-release-notes-assets.yml)
+workflow syncs this directory to S3 and invalidates the CloudFront cache. The
+sync is additive: it uploads new or changed files and never deletes existing
+ones. You can also run the workflow manually from the Actions tab (for example,
+to publish to the `staging` or `dailies` channel) once you have write access.
+
+Because assets publish on merge, you can merge an assets-only change first, then
+author the release notes against the live CDN URL and preview the real
+rendering.
+
+## Naming and referencing
+
+Name files `<year>-<month>-<slug>.<ext>`, for example `2026-06-posit-assistant.gif`.
+
+Reference them with the absolute CDN URL (not a relative path), centered with a
+`<p align="center">` wrapper:
+
+```html
+<p align="center"><img src="https://cdn.posit.co/positron/releases/release-notes/assets/2026-06-posit-assistant.gif" alt="Describe the image"></p>
+```
+
+This file is excluded from the S3 sync.


### PR DESCRIPTION
This PR adds a way to keep release-notes images and GIFs version controlled in this repo and publish them to the CDN automatically, instead of uploading them out of band.

Release notes reference images by absolute CDN URL (`https://cdn.posit.co/positron/releases/release-notes/assets/<name>`), but until now those asset files lived only on the CDN and were never committed here. This PR makes `release-notes/assets/` the source of truth and wires up the upload.

## What's included

- **New workflow `publish-release-notes-assets.yml`**: syncs `release-notes/assets/` to `s3://posit-positron-downloads/positron/<channel>/release-notes/assets/` and invalidates the CloudFront cache for that prefix. It runs automatically on merge to `main` when anything under `release-notes/assets/**` changes, and can also be dispatched manually to pick a channel (`releases`, `staging`, `dailies`; defaults to `releases`). It reuses the same OIDC roles and secrets as the existing publish workflows (`AWS_S3_RW_ROLE`, `AWS_CDN_RW_ROLE`, `AWS_CDN_DISTRIBUTION_ID`).
- **`release-notes/assets/` directory** with a `README.md` documenting the naming convention (`<year>-<month>-<slug>.<ext>`), the CDN URL reference pattern, and how the sync works.
- **`prepare-release-notes` skill**: a guided checklist for authoring `next.md`, including the in-product image preview loop and the steps to move an asset into `release-notes/assets/` before committing. I added this because honestly this process is a big pain in the neck. 😭 
- **CLAUDE.md**: documents the new workflow in the CI/CD section.

## Notes on design

- The sync is additive (`aws s3 sync` with no `--delete`), so it only uploads new or changed files, never removes existing assets, and is safe to re-run.
- This is a public repo, but only collaborators with write access can merge to `main` or trigger `workflow_dispatch`, and fork pull requests can never trigger the workflow or reach the secrets. So no extra approval gate was added.
- A `concurrency` group prevents two quick merges from racing on the same prefix.
- `README.md` is excluded from the sync so it does not land on the CDN.

## Authoring impact

Because assets now publish on merge, you can merge an assets-only change first, get the live CDN URL, and author the release notes against it to preview the real rendering. The in-product local-file preview trick still works for iterating before getting anything up on the CDN.
