### PR TITLE
Assistant: update foundry status and google provider names

### DIFF
--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -40,7 +40,7 @@ To connect a provider, run the command _Authentication: Configure Language Model
 | [Custom Provider](assistant-providers.qmd#custom-provider) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [DeepSeek](assistant-providers.qmd#deepseek) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [Gemini Code Assist](assistant-providers.qmd#gemini-code-assist) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
-| [Google Vertex AI](assistant-providers.qmd#google-vertex-ai) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | Google Cloud CLI or Service Account Credentials |
+| [Gemini Enterprise Agent Platform](assistant-providers.qmd#gemini-enterprise-agent-platform) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | Google Cloud CLI or Service Account Credentials |
 
 Please ensure you consult your provider's privacy policy for information on the data they collect and how they use it. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.
 

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -39,7 +39,7 @@ To connect a provider, run the command _Authentication: Configure Language Model
 | [GitHub Copilot](assistant-providers.qmd#github-copilot) [Preview]{.provider-badge .preview} | {{< fa check >}} | {{< fa check >}} | OAuth |
 | [Custom Provider](assistant-providers.qmd#custom-provider) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [DeepSeek](assistant-providers.qmd#deepseek) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
-| [Gemini Code Assist](assistant-providers.qmd#gemini-code-assist) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
+| [Google Gemini](assistant-providers.qmd#gemini-code-assist) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [Gemini Enterprise Agent Platform](assistant-providers.qmd#gemini-enterprise-agent-platform) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | Google Cloud CLI or Service Account Credentials |
 
 Please ensure you consult your provider's privacy policy for information on the data they collect and how they use it. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -33,10 +33,10 @@ To connect a provider, run the command _Authentication: Configure Language Model
 | [Posit AI](assistant-providers.qmd#posit-ai) | {{< fa check >}} | {{< fa check >}} | OAuth |
 | [Amazon Bedrock](assistant-providers.qmd#amazon-bedrock) | {{< fa check >}} | | AWS CLI or Posit Workbench Managed Credentials |
 | [Anthropic](assistant-providers.qmd#anthropic) | {{< fa check >}} | | API Key |
+| [Microsoft Foundry](assistant-providers.qmd#microsoft-foundry) | {{< fa check >}} | | API Key or Workbench Managed Credentials |
 | [OpenAI](assistant-providers.qmd#openai) | {{< fa check >}} | | API Key |
 | [Snowflake Cortex](assistant-providers.qmd#snowflake-cortex) | {{< fa check >}} | | API Key or Workbench Managed Credentials |
 | [GitHub Copilot](assistant-providers.qmd#github-copilot) [Preview]{.provider-badge .preview} | {{< fa check >}} | {{< fa check >}} | OAuth |
-| [Microsoft Foundry](assistant-providers.qmd#microsoft-foundry) [Preview]{.provider-badge .preview} | {{< fa check >}} | | API Key or Workbench Managed Credentials |
 | [Custom Provider](assistant-providers.qmd#custom-provider) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [DeepSeek](assistant-providers.qmd#deepseek) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |
 | [Gemini Code Assist](assistant-providers.qmd#gemini-code-assist) [Experimental]{.provider-badge .experimental} | {{< fa check >}} | | API Key |

--- a/assistant-provider-info.qmd
+++ b/assistant-provider-info.qmd
@@ -35,11 +35,11 @@ Any Provider is considered "Third Party Materials" as defined in the [Posit End 
 * [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)
 * [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
 
-### Google Vertex AI
+### Gemini Enterprise Agent Platform
 
 * [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)
 * [Google Cloud Platform Terms of Service](https://cloud.google.com/terms)
-* [Generative AI on Vertex AI Data Governance](https://cloud.google.com/vertex-ai/generative-ai/docs/data-governance)
+* [Gemini Enterprise Agent Platform and zero data retention](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/zero-data-retention)
 
 ### OpenAI
 * [Privacy Policy](https://openai.com/policies/row-privacy-policy/)

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -89,34 +89,7 @@ Anthropic does not include Claude API usage in its [Pro](https://support.claude.
 
 Support for OAuth sign-in depends on Anthropic offering API access to Posit Assistant through these plans. You can follow [this feature request](https://github.com/posit-dev/positron/issues/9481) for updates.
 
-## OpenAI
-
-- **Account:** an OpenAI account, or any service that implements the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
-- **Authentication:** an OpenAI API key, or the `OPENAI_API_KEY` environment variable. For a compatible service, also provide its base URL (or the `OPENAI_BASE_URL` environment variable)
-
-## Snowflake Cortex
-
-- **Account:** a Snowflake account with Cortex access
-- **Authentication:** your Snowflake [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier) and a [programmatic access token](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) (PAT)
-- **Settings:**
-  - [`authentication.snowflake.credentials`](positron://settings/authentication.snowflake.credentials) (required): add your account ID as an item with the key `SNOWFLAKE_ACCOUNT` before you connect
-
-## GitHub Copilot [Preview]{.provider-badge .preview} {#github-copilot}
-
-- **Account:** a GitHub account with Copilot enabled
-- **Authentication:** sign in through your browser with OAuth
-
-### Get GitHub Copilot access
-
-GitHub Copilot is a proprietary tool from GitHub. To use GitHub Copilot for AI chat and code completions, you need a [subscription for GitHub Copilot](https://docs.github.com/en/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot) in your personal GitHub account. You can also be assigned a seat by an organization with a GitHub Copilot for Business subscription.
-
-Students and faculty can use GitHub Copilot for free as part of the GitHub Education program. For more information, see the [GitHub Education page](https://education.github.com/).
-
-::: {.callout-note}
-You can also sign in to GitHub via the {{< fa circle-user >}} **Accounts** icon in the Activity Bar. To sign out, use the Accounts icon or run the _Accounts: Manage Accounts_ command. The Accounts section manages your GitHub authentication for all extensions that use GitHub, not just AI features.
-:::
-
-## Microsoft Foundry [Preview]{.provider-badge .preview} {#microsoft-foundry}
+## Microsoft Foundry {#microsoft-foundry}
 
 - **Account:** a [Microsoft Foundry](https://ai.azure.com/) resource with one or more models deployed
 - **Authentication:** the endpoint URL and API key for your Foundry resource
@@ -143,6 +116,33 @@ To use specific models instead of `model-router`, configure the [`positron.assis
 ```
 
 Use the model name and deployment identifier from your Foundry resource for each entry.
+
+## OpenAI
+
+- **Account:** an OpenAI account, or any service that implements the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
+- **Authentication:** an OpenAI API key, or the `OPENAI_API_KEY` environment variable. For a compatible service, also provide its base URL (or the `OPENAI_BASE_URL` environment variable)
+
+## Snowflake Cortex
+
+- **Account:** a Snowflake account with Cortex access
+- **Authentication:** your Snowflake [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier) and a [programmatic access token](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) (PAT)
+- **Settings:**
+  - [`authentication.snowflake.credentials`](positron://settings/authentication.snowflake.credentials) (required): add your account ID as an item with the key `SNOWFLAKE_ACCOUNT` before you connect
+
+## GitHub Copilot [Preview]{.provider-badge .preview} {#github-copilot}
+
+- **Account:** a GitHub account with Copilot enabled
+- **Authentication:** sign in through your browser with OAuth
+
+### Get GitHub Copilot access
+
+GitHub Copilot is a proprietary tool from GitHub. To use GitHub Copilot for AI chat and code completions, you need a [subscription for GitHub Copilot](https://docs.github.com/en/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot) in your personal GitHub account. You can also be assigned a seat by an organization with a GitHub Copilot for Business subscription.
+
+Students and faculty can use GitHub Copilot for free as part of the GitHub Education program. For more information, see the [GitHub Education page](https://education.github.com/).
+
+::: {.callout-note}
+You can also sign in to GitHub via the {{< fa circle-user >}} **Accounts** icon in the Activity Bar. To sign out, use the Accounts icon or run the _Accounts: Manage Accounts_ command. The Accounts section manages your GitHub authentication for all extensions that use GitHub, not just AI features.
+:::
 
 ## Custom Provider [Experimental]{.provider-badge .experimental} {#custom-provider}
 

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -171,7 +171,7 @@ Some OpenAI-compatible providers might not implement the `/models` endpoint, whi
 - **Account:** a [DeepSeek](https://platform.deepseek.com/) account with API access
 - **Authentication:** a DeepSeek API key, or the `DEEPSEEK_API_KEY` environment variable
 
-## Gemini Code Assist [Experimental]{.provider-badge .experimental} {#gemini-code-assist}
+## Google Gemini [Experimental]{.provider-badge .experimental} {#gemini-code-assist}
 
 - **Account:** a Google account with access to the [Gemini API](https://ai.google.dev/), with an API key created in [Google AI Studio](https://aistudio.google.com/apikey)
 - **Authentication:** a Gemini API key, or the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variable

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -176,9 +176,11 @@ Some OpenAI-compatible providers might not implement the `/models` endpoint, whi
 - **Account:** a Google account with access to the [Gemini API](https://ai.google.dev/), with an API key created in [Google AI Studio](https://aistudio.google.com/apikey)
 - **Authentication:** a Gemini API key, or the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variable
 
-## Google Vertex AI [Experimental]{.provider-badge .experimental} {#google-vertex-ai}
+## Gemini Enterprise Agent Platform [Experimental]{.provider-badge .experimental} {#gemini-enterprise-agent-platform}
 
-- **Account:** a Google Cloud project with the [Vertex AI API enabled](https://cloud.google.com/vertex-ai/docs/start/cloud-environment) and [access to the models](https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models) you want to use
+Formerly Google Vertex AI.
+
+- **Account:** a Google Cloud project with the [Agent Platform APIs enabled](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/start/cloud-environment) and [access to the models](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-garden/explore-models) you want to use
 - **Authentication:** authenticate with Google Cloud using Application Default Credentials (`gcloud`) or a service account (see below)
 - **Settings:**
   - [`authentication.googleVertex.credentials`](positron://settings/authentication.googleVertex.credentials) (required, or env vars): set your project ID and location, which take precedence over the `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` environment variables


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/13810

- moves foundry to GA
- rename google vertex to GEAP
- fix misnaming of gemini provider to google gemini