### PR TITLE
Enable llms.txt generation for the Workbench docs build

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -7,7 +7,6 @@ website:
   open-graph: true
   bread-crumbs: true
   page-navigation: true
-  llms-txt: true
   favicon: "images/favicon.svg"
   image: "images/positron-social.png"
   search:

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -21,6 +21,7 @@ website:
   open-graph: true
   bread-crumbs: true
   page-navigation: true
+  llms-txt: true
   favicon: "images/favicon.svg"
   image: "images/positron-social.png"
   search:

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -21,7 +21,6 @@ website:
   open-graph: true
   bread-crumbs: true
   page-navigation: true
-  llms-txt: true
   favicon: "images/favicon.svg"
   image: "images/positron-social.png"
   search:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,6 +7,9 @@ project:
 execute:
   freeze: auto
 
+website:
+  llms-txt: true
+
 profile:
   group: 
     - [positron, workbench]


### PR DESCRIPTION
## Problem

The docs we bundle with Workbench don't include `llms.txt` or the markdown versions of the doc pages. Only the public site build (`_quarto-positron.yml`) had `llms-txt: true` turned on.

Posit Assistant is getting a skill that answers Positron questions by fetching `llms.txt` and the markdown docs (https://github.com/posit-dev/assistant/pull/1768). For Workbench users we want the skill to eventually read the docs bundled with Workbench since those match the installed Positron version, so the Workbench build needs to generate these files too. I moved the setting to the base `_quarto.yml` so every build gets it.

As a follow-up, Posit Assistant still needs a way to know the Workbench docs URL before it can use these files. That work is tracked in posit-dev/positron#14690.