### PR TITLE
Restructure AI docs around Posit Assistant and deprecate the old assistants

### DIFF
--- a/_positron-assistant-deprecated.qmd
+++ b/_positron-assistant-deprecated.qmd
@@ -1,5 +1,7 @@
 ::: {.callout-warning}
-## Positron Assistant has been removed
+## Positron Assistant is deprecated
 
-This page covers Positron Assistant, the old chat experience that has been removed and replaced by [Posit Assistant](https://pos.it/assistant). Use Posit Assistant instead, and see the [Posit Assistant documentation](https://pos.it/assistant-docs) to get set up.
+This page documents Positron Assistant, the previous AI chat and completions experience, which has been deprecated and replaced by [Posit Assistant](https://assistant.posit.co) as of Positron 2026.07. These docs remain in place for folks on older builds of Positron.
+
+If you're on a current build, use Posit Assistant instead and see the [Posit Assistant documentation](https://assistant.posit.co) to get set up. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 :::

--- a/_positron-assistant-deprecated.qmd
+++ b/_positron-assistant-deprecated.qmd
@@ -3,5 +3,5 @@
 
 This page documents Positron Assistant, the previous AI chat and completions experience, which has been deprecated and replaced by [Posit Assistant](https://assistant.posit.co) as of Positron 2026.07. These docs remain in place for folks on older builds of Positron.
 
-If you're on a current build, use Posit Assistant instead and see the [Posit Assistant documentation](https://assistant.posit.co) to get set up. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
+If you are on Positron 2026.07 or later, see the [Posit Assistant documentation](https://assistant.posit.co) to get set up with Posit Assistant. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 :::

--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -102,29 +102,30 @@ website:
             - command-palette.qmd
             - action-bars.qmd
             - help-pane.qmd
-        - section: "AI Tools"
+        - section: "Assistant"
+          href: assistant.qmd
           contents:
-            - section: "Assistant"
-              href: assistant.qmd
+          - text: "Overview"
+            href: assistant.qmd
+          - assistant-getting-started.qmd
+          - assistant-providers.qmd
+          - assistant-completions.qmd
+          - assistant-provider-info.qmd
+          - section: "Positron Assistant (deprecated)"
+            contents:
+            - section: "Chat"
+              href: assistant-chat.qmd
               contents:
-              - text: "Overview"
-                href: assistant.qmd
-              - assistant-getting-started.qmd
-              - assistant-providers.qmd
-              - section: "Chat"
-                href: assistant-chat.qmd
-                contents:
-                  - text: "Overview"
-                    href: assistant-chat.qmd
-                  - href: assistant-chat-agents.qmd
-                  - href: assistant-chat-context.qmd
-                  - href: assistant-chat-commands-participants.qmd
-                  - href: assistant-chat-instructions.qmd
-              - assistant-completions.qmd
-              - assistant-troubleshooting.qmd
-              - assistant-tips.qmd
-              - assistant-provider-info.qmd
-            - databot.qmd
+                - text: "Overview"
+                  href: assistant-chat.qmd
+                - href: assistant-chat-agents.qmd
+                - href: assistant-chat-context.qmd
+                - href: assistant-chat-commands-participants.qmd
+                - href: assistant-chat-instructions.qmd
+            - assistant-troubleshooting.qmd
+            - assistant-tips.qmd
+          - text: "Databot (deprecated)"
+            href: databot.qmd
         - section: "Language Guides"
           href: language-guides.qmd
           contents:

--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -102,10 +102,10 @@ website:
             - command-palette.qmd
             - action-bars.qmd
             - help-pane.qmd
-        - section: "Assistant"
+        - section: "AI Features"
           href: assistant.qmd
           contents:
-          - text: "Overview"
+          - text: "Posit Assistant"
             href: assistant.qmd
           - assistant-getting-started.qmd
           - assistant-providers.qmd

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -102,29 +102,30 @@ website:
             - command-palette.qmd
             - action-bars.qmd
             - help-pane.qmd
-        - section: "AI Tools"
+        - section: "Assistant"
+          href: assistant.qmd
           contents:
-            - section: "Assistant"
-              href: assistant.qmd
+          - text: "Overview"
+            href: assistant.qmd
+          - assistant-getting-started.qmd
+          - assistant-providers.qmd
+          - assistant-completions.qmd
+          - assistant-provider-info.qmd
+          - section: "Positron Assistant (deprecated)"
+            contents:
+            - section: "Chat"
+              href: assistant-chat.qmd
               contents:
-              - text: "Overview"
-                href: assistant.qmd
-              - assistant-getting-started.qmd
-              - assistant-providers.qmd
-              - section: "Chat"
-                href: assistant-chat.qmd
-                contents:
-                  - text: "Overview"
-                    href: assistant-chat.qmd
-                  - href: assistant-chat-agents.qmd
-                  - href: assistant-chat-context.qmd
-                  - href: assistant-chat-commands-participants.qmd
-                  - href: assistant-chat-instructions.qmd
-              - assistant-completions.qmd
-              - assistant-troubleshooting.qmd
-              - assistant-tips.qmd
-              - assistant-provider-info.qmd
-            - databot.qmd
+                - text: "Overview"
+                  href: assistant-chat.qmd
+                - href: assistant-chat-agents.qmd
+                - href: assistant-chat-context.qmd
+                - href: assistant-chat-commands-participants.qmd
+                - href: assistant-chat-instructions.qmd
+            - assistant-troubleshooting.qmd
+            - assistant-tips.qmd
+          - text: "Databot (deprecated)"
+            href: databot.qmd
         - section: "Language Guides"
           href: language-guides.qmd
           contents:

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -102,10 +102,10 @@ website:
             - command-palette.qmd
             - action-bars.qmd
             - help-pane.qmd
-        - section: "Assistant"
+        - section: "AI Features"
           href: assistant.qmd
           contents:
-          - text: "Overview"
+          - text: "Posit Assistant"
             href: assistant.qmd
           - assistant-getting-started.qmd
           - assistant-providers.qmd

--- a/assistant-chat-agents.qmd
+++ b/assistant-chat-agents.qmd
@@ -8,7 +8,7 @@ description: "Customize AI behavior with chat agents in Positron Assistant. Choo
 ::: {.callout-note}
 ## Migrating to Posit Assistant?
 
-Posit Assistant manages tool use and agent behavior through permissions. See [Permissions](https://posit-dev.github.io/assistant/docs/features/permissions/) in the Posit Assistant documentation.
+Posit Assistant manages tool use and agent behavior through permissions. See [Permissions](https://assistant.posit.co/docs/features/permissions/) in the Posit Assistant documentation.
 :::
 
 Chat agents tailor Assistant's behavior for specific tasks by providing unique instructions and tools. Select the agent selector dropdown at the bottom of the chat pane to switch between agents.

--- a/assistant-chat-commands-participants.qmd
+++ b/assistant-chat-commands-participants.qmd
@@ -8,7 +8,7 @@ description: "Speed up your workflow with slash commands and chat participants i
 ::: {.callout-note}
 ## Migrating to Posit Assistant?
 
-Posit Assistant has its own set of slash commands. See [Commands](https://posit-dev.github.io/assistant/docs/features/commands/) in the Posit Assistant documentation.
+Posit Assistant has its own set of slash commands. See [Commands](https://assistant.posit.co/docs/features/commands/) in the Posit Assistant documentation.
 :::
 
 ## Slash commands

--- a/assistant-chat-context.qmd
+++ b/assistant-chat-context.qmd
@@ -8,7 +8,7 @@ description: "Give Positron Assistant context from your data, plots, Console act
 ::: {.callout-note}
 ## Migrating to Posit Assistant?
 
-Posit Assistant handles context in its own way. See [Context management](https://posit-dev.github.io/assistant/docs/features/context-management/) in the Posit Assistant documentation.
+Posit Assistant handles context in its own way. See [Context management](https://assistant.posit.co/docs/features/context-management/) in the Posit Assistant documentation.
 :::
 
 Positron Assistant goes beyond reading your code files. It also accesses your loaded data, plots, and Console activity by calling tools and executing code in your R or Python interpreter session or running commands in the Terminal.

--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -38,10 +38,6 @@ To open the chat pane, click the chat robot icon in the sidebar or run the comma
 
 Inline chat is a mini chat interface that can be opened directly within your code Editor, Notebook, or Terminal. It allows you to ask questions, get suggestions, and apply changes without leaving your current context.
 
-::: {.callout-important}
-Inline chat is only available in Positron Assistant. [Posit Assistant](https://pos.it/assistant) does not support inline chat.
-:::
-
 ::: {.panel-tabset group="inline-chat-area"}
 
 ## Editor or notebook

--- a/assistant-chat.qmd
+++ b/assistant-chat.qmd
@@ -8,7 +8,7 @@ description: "Use the Positron Assistant chat pane for AI-powered coding help, i
 ::: {.callout-note}
 ## Migrating to Posit Assistant?
 
-See [Chat features](https://posit-dev.github.io/assistant/docs/features/chat-features/) in the Posit Assistant documentation.
+See [Chat features](https://assistant.posit.co/docs/features/chat-features/) in the Posit Assistant documentation.
 :::
 
 Positron Assistant provides multiple ways to interact with AI assistance across your workspace. Whether you use the dedicated chat pane, inline chat within your Editor or Terminal, or quick Console actions for errors, Assistant works within your development environment.

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -102,6 +102,6 @@ If you are not receiving suggestions:
 
 - Check that [`ai.enabled`](positron://settings/ai.enabled) is not set to `false`. When it is, Positron disables all AI features including code completions, regardless of other settings.
 - Confirm you are signed in to your completions provider in the [language model provider configuration](assistant-getting-started.qmd#configure-a-language-model-provider).
-- Check that your completions provider's per-language settings do not disable the current language (see [Posit AI Next Edit Suggestions](#posit-ai-next-edit-suggestions-nes) or [GitHub Copilot](#github-copilot)).
+- Check that your completions provider's per-language settings do not disable the current language (see [Posit AI Next Edit Suggestions](#posit-ai-nes) or [GitHub Copilot](#github-copilot)).
 - Check that [`positron.assistant.aiExcludes`](positron://settings/positron.assistant.aiExcludes) does not match the current file.
 - Refer to the [Troubleshooting](assistant-troubleshooting.qmd) guide for more help.

--- a/assistant-getting-started.qmd
+++ b/assistant-getting-started.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Get started"
 description: "Set up AI assistance in Positron: configure a language model provider such as Posit AI, Anthropic, or GitHub Copilot, then use AI features in Positron, such as Posit Assistant."
 listing:
   - id: ai-features
@@ -13,7 +13,7 @@ listing:
       - title: "Notebook AI assistance"
         description: "Notebook-aware AI that understands your cells, outputs, and execution history."
         icon: "bi-journal-code"
-        link: "positron-notebook-editor.qmd#positron-assistant-integration"
+        link: "positron-notebook-editor.qmd#ai-integration"
       - title: "Code completions"
         description: "Receive code suggestions directly in your Editor or Notebook."
         icon: "bi-cursor-text"
@@ -50,7 +50,7 @@ Please ensure you consult your provider's privacy policy for information on the 
 
 With a language model provider configured, you can use AI throughout Positron. To start a chat, run the _View: Show Posit Assistant_ command in the Command Palette to open the chat panel.
 
-For the full Posit Assistant configuration guide and feature documentation, see the [Posit Assistant documentation](https://pos.it/assistant-docs).
+For the full Posit Assistant configuration guide and feature documentation, see the [Posit Assistant documentation](https://assistant.posit.co/docs/getting-started/).
 
 ::: {#ai-features}
 :::

--- a/assistant-provider-info.qmd
+++ b/assistant-provider-info.qmd
@@ -7,11 +7,18 @@ description: "Information about data handling, privacy, and terms of service for
 {{< include _privacy-link.qmd >}}
 :::
 
-When you use AI features in Positron, Positron might share data including your prompts, responses, and usage with third-party AI model providers such as Anthropic and GitHub Copilot, depending on the providers you use. Each provider has its own data handling, privacy policies, and terms of service.
+When you use AI features in Positron, Positron might share data including your prompts, responses, and usage with third-party AI model providers, depending on the providers you use. Each provider has its own data handling, privacy policies, and terms of service.
 
 Please review your providers' websites directly for complete and updated details on their data practices and terms of service. This list might not be up to date.
 
 Any Provider is considered "Third Party Materials" as defined in the [Posit End User License Agreement](https://posit.co/about/eula/) and Posit assumes no liability or other obligations with respect thereto and, without limiting the foregoing, is not liable for any loss or damage resulting from the use or access thereof.
+
+### Posit AI
+
+Posit AI is Posit's own hosted service, so Posit's own policies apply rather than a third party's.
+
+* [Privacy Policy](https://posit.co/about/privacy-policy/)
+* [Posit AI Agreement](https://posit.co/about/posit-ai-agreement)
 
 ### Amazon Bedrock
 
@@ -30,22 +37,40 @@ Any Provider is considered "Third Party Materials" as defined in the [Posit End 
 * [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement)
 * [Azure AI Services Terms](https://www.microsoft.com/licensing/terms/productoffering/MicrosoftAzure)
 
+### OpenAI
+
+* [Privacy Policy](https://openai.com/policies/row-privacy-policy/)
+* [Privacy Portal](https://privacy.openai.com/policies/en/?name=welcome-to-open-ai-privacy-portal)
+* [Terms of Use](https://openai.com/policies/row-terms-of-use/)
+
+### Snowflake Cortex
+
+* [Privacy Policy](https://www.snowflake.com/en/legal/privacy/privacy-policy/)
+* [Terms of Service](https://www.snowflake.com/en/legal/terms-of-service/)
+
 ### GitHub Copilot
 
 * [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)
 * [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
+
+### Custom Provider
+
+The custom provider connects to any OpenAI-compatible endpoint you configure, so its data handling and terms depend entirely on the provider you choose. Review that provider's own privacy policy and terms of service directly.
+
+### DeepSeek
+
+* [Privacy Policy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html)
+* [Terms of Use](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html)
+* [Open Platform Terms of Service](https://cdn.deepseek.com/policies/en-US/deepseek-open-platform-terms-of-service.html)
+
+### Google Gemini
+
+* [Privacy Policy](https://policies.google.com/privacy)
+* [Google APIs Terms of Service](https://developers.google.com/terms)
+* [Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms)
 
 ### Gemini Enterprise Agent Platform
 
 * [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)
 * [Google Cloud Platform Terms of Service](https://cloud.google.com/terms)
 * [Gemini Enterprise Agent Platform and zero data retention](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/zero-data-retention)
-
-### OpenAI
-* [Privacy Policy](https://openai.com/policies/row-privacy-policy/)
-* [Privacy Portal](https://privacy.openai.com/policies/en/?name=welcome-to-open-ai-privacy-portal)
-* [Terms of Use](https://openai.com/policies/row-terms-of-use/)
-
-### Snowflake Cortex
-* [Privacy Policy](https://www.snowflake.com/en/legal/privacy/privacy-policy/)
-* [Terms of Service](https://www.snowflake.com/en/legal/terms-of-service/)

--- a/assistant-provider-info.qmd
+++ b/assistant-provider-info.qmd
@@ -32,6 +32,29 @@ Posit AI is Posit's own hosted service, so Posit's own policies apply rather tha
 * [Console Privacy Controls](https://platform.claude.com/settings/privacy)
 * [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms)
 
+### DeepSeek
+
+* [Privacy Policy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html)
+* [Terms of Use](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html)
+* [Open Platform Terms of Service](https://cdn.deepseek.com/policies/en-US/deepseek-open-platform-terms-of-service.html)
+
+### Gemini Enterprise Agent Platform
+
+* [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)
+* [Google Cloud Platform Terms of Service](https://cloud.google.com/terms)
+* [Gemini Enterprise Agent Platform and zero data retention](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/zero-data-retention)
+
+### GitHub Copilot
+
+* [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)
+* [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
+
+### Google Gemini
+
+* [Privacy Policy](https://policies.google.com/privacy)
+* [Google APIs Terms of Service](https://developers.google.com/terms)
+* [Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms)
+
 ### Microsoft Foundry
 
 * [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement)
@@ -48,29 +71,6 @@ Posit AI is Posit's own hosted service, so Posit's own policies apply rather tha
 * [Privacy Policy](https://www.snowflake.com/en/legal/privacy/privacy-policy/)
 * [Terms of Service](https://www.snowflake.com/en/legal/terms-of-service/)
 
-### GitHub Copilot
-
-* [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect)
-* [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot)
-
 ### Custom Provider
 
 The custom provider connects to any OpenAI-compatible endpoint you configure, so its data handling and terms depend entirely on the provider you choose. Review that provider's own privacy policy and terms of service directly.
-
-### DeepSeek
-
-* [Privacy Policy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html)
-* [Terms of Use](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html)
-* [Open Platform Terms of Service](https://cdn.deepseek.com/policies/en-US/deepseek-open-platform-terms-of-service.html)
-
-### Google Gemini
-
-* [Privacy Policy](https://policies.google.com/privacy)
-* [Google APIs Terms of Service](https://developers.google.com/terms)
-* [Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms)
-
-### Gemini Enterprise Agent Platform
-
-* [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)
-* [Google Cloud Platform Terms of Service](https://cloud.google.com/terms)
-* [Gemini Enterprise Agent Platform and zero data retention](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/zero-data-retention)

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -12,7 +12,7 @@ Please ensure you consult your provider's privacy policy for information on the 
 
 ## Posit AI
 
-Posit AI is a hosted language model service from Posit, offering both chat models and code completions through [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-next-edit-suggestions-nes).
+Posit AI is a hosted language model service from Posit, offering both chat models and code completions through [Next Edit Suggestions (NES)](assistant-completions.qmd#posit-ai-nes).
 
 - **Account:** a Posit AI account, which you can create at [posit.ai](https://posit.ai/)
 - **Authentication:** sign in through your browser with OAuth

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -8,7 +8,7 @@ Positron connects to a range of language model providers. To connect one, run th
 
 This page covers what each provider needs: the account to have ready, how you authenticate, and any Positron settings to configure first.
 
-Please ensure you consult your provider's privacy policy for information on the data they collect and how it is used. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.
+Please ensure you consult your provider's privacy policy and terms of service for information on the data they collect and how it is used. For reference links, see the [Provider Privacy Information](assistant-provider-info.qmd) guide.
 
 ## Posit AI
 

--- a/assistant-troubleshooting.qmd
+++ b/assistant-troubleshooting.qmd
@@ -8,10 +8,10 @@ description: "Solve common Positron Assistant issues with troubleshooting guides
 ::: {.callout-note}
 ## Having trouble with Posit Assistant?
 
-If your issue is with [Posit Assistant](https://pos.it/assistant) rather than Positron Assistant, reach out in the [assistant-feedback repository](https://github.com/posit-dev/assistant-feedback).
+If your issue is with [Posit Assistant](https://assistant.posit.co) rather than Positron Assistant, reach out in the [assistant-feedback repository](https://github.com/posit-dev/assistant-feedback).
 :::
 
-If you are having trouble with Positron Assistant, here are some resources and tools to help diagnose the issue and get things working smoothly. Keep in mind that Positron Assistant is being deprecated, so [migrating to Posit Assistant](https://pos.it/assistant-docs) might be the best way to resolve your issue.
+If you are having trouble with Positron Assistant, here are some resources and tools to help diagnose the issue and get things working smoothly.
 
 Cannot find what you are looking for? Reach out through our [feedback channels](#feedback-issues) and we will help you out!
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -23,7 +23,7 @@ listing:
 ::: {.callout-note}
 ## Looking for Positron Assistant?
 
-Positron Assistant has been removed and replaced by Posit Assistant as of Positron 2026.07.
+Posit Assistant replaces Positron Assistant as of Positron 2026.07.
 :::
 
 [Posit Assistant](https://pos.it/assistant) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Posit Assistant"
-description: "Posit Assistant is the new AI coding experience in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience built for data science."
+description: "Posit Assistant is the AI coding experience in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience built for data science."
 listing:
   - id: learn-more
     type: custom
@@ -23,7 +23,7 @@ listing:
 ::: {.callout-note}
 ## Looking for Positron Assistant?
 
-Positron Assistant has been removed and replaced by Posit Assistant.
+Positron Assistant has been removed and replaced by Posit Assistant as of Positron 2026.07.
 :::
 
 [Posit Assistant](https://pos.it/assistant) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -50,7 +50,7 @@ Posit Assistant has a rich set of features with the highlights listed below.
 
 ## Support and terms of service
 
-Posit does not provide support or assistance for any code written or generated in Positron, with or without Posit Assistant, Positron Assistant, or Databot via any model provider. Posit does not support the Anthropic or GitHub Copilot output, or test the logic used by either to generate code from prompts. Consult your AI model provider's [documentation](assistant-provider-info.qmd) for more information.
+Posit does not provide support or assistance for any code written or generated in Positron, with or without Posit Assistant, Positron Assistant, or Databot, regardless of which model provider you use. Posit does not support any model provider's output or test the logic a provider uses to generate code from prompts. Consult your AI model provider's [documentation](assistant-provider-info.qmd) for more information.
 
 ### Positron AI agents
 
@@ -62,7 +62,7 @@ Positron provides local software as a client to the user's selected model provid
 
 If you voluntarily share diagnostic logs or information with Posit for troubleshooting purposes, that shared information will be handled in accordance with [[Posit's privacy policy](privacy.qmd)]{.content-visible when-profile="positron"}[[Posit's privacy policy](https://posit.co/about/privacy-policy/)]{.content-visible when-profile="workbench"}.
 
-However, your AI model provider (such as [Anthropic](assistant-provider-info.qmd#anthropic) or [GitHub Copilot](assistant-provider-info.qmd#github-copilot)) may store or collect data according to their own privacy policies and terms of service. Please review your [AI model provider's data practices](assistant-provider-info.qmd) for details on what information they collect and how it's used.
+However, your AI model provider may store or collect data according to their own privacy policies and terms of service. Please review your [AI model provider's data practices](assistant-provider-info.qmd) for details on what information they collect and how it is used.
 
 By using an external model provider, you acknowledge that your use is subject to their Terms of Service. All external model providers are considered “Third Party Materials” as defined in the [Posit End User License Agreement](https://posit.co/about/eula/) and Posit assumes no liability or other obligations with respect thereto and, without limiting the foregoing, is not liable for any loss or damage resulting from the use or access thereof.
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -7,9 +7,9 @@ listing:
     template: templates/welcome-card.ejs
     contents:
       - title: "Get Started"
-        description: "Set up Posit Assistant and learn the essentials for your first conversation."
+        description: "Configure a language model provider and start using Posit Assistant in Positron."
         icon: "bi-rocket-takeoff"
-        link: "https://pos.it/assistant-docs"
+        link: "assistant-getting-started.qmd"
       - title: "Posit Assistant vs. Positron Assistant"
         description: "Watch a walkthrough comparing Posit Assistant and Positron Assistant."
         icon: "bi-play-circle"
@@ -26,11 +26,11 @@ listing:
 Posit Assistant replaces Positron Assistant as of Positron 2026.07.
 :::
 
-[Posit Assistant](https://pos.it/assistant) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.
+[Posit Assistant](https://assistant.posit.co) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.
 
 Beyond your active files, selected code, and project structure, Posit Assistant uses context from your interactive data science work, such as your loaded data, plots, and console history. This enables more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
 
-To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://pos.it/assistant-docs).
+To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://assistant.posit.co/docs/getting-started/).
 
 ## Features
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Posit Assistant"
-description: "Posit Assistant is the AI coding experience in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience built for data science."
+description: "Posit Assistant is an AI coding assistant for data science in Positron, bringing together the capabilities of Positron Assistant and Databot in a unified experience."
 listing:
   - id: learn-more
     type: custom
@@ -20,7 +20,7 @@ listing:
         link: "https://opensource.posit.co/topics/artificial-intelligence/"
 ---
 
-[Posit Assistant](https://assistant.posit.co) is the AI coding experience in Positron. It first became available as a preview feature in Positron 2026.04.0, and as of Positron 2026.07 it is the built-in AI experience, replacing Positron Assistant and Databot. For more on how it came to be, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
+[Posit Assistant](https://assistant.posit.co) is an AI coding assistant for data science in Positron. It first became available as a preview feature in Positron 2026.04.0, and as of Positron 2026.07 it ships with Positron as the default AI experience, replacing Positron Assistant and Databot. For more on how it came to be, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 
 Beyond your active files, selected code, and project structure, Posit Assistant uses context from your interactive data science work, such as your loaded data, plots, and console history. This enables more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
 
@@ -33,13 +33,13 @@ Posit Assistant has a rich set of features with the highlights listed below.
 ::: {.features-table}
 | Feature | Summary |
 | --- | --- |
-| [Commands](https://assistant.posit.co/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions — for example, `/plan`, `/new`, and `/savememory`. |
+| [Commands](https://assistant.posit.co/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions, such as `/plan`, `/new`, and `/savememory`. |
 | [Skills](https://assistant.posit.co/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Built-ins include `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
 | [Memory](https://assistant.posit.co/docs/features/memory/) | Persistent project context via an `AGENTS.md` file that captures conventions, architecture, and preferences. The file loads automatically at the start of every conversation in trusted workspaces. |
-| [Conversations](https://assistant.posit.co/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion. Includes tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
+| [Conversations](https://assistant.posit.co/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion. Includes tree-based branching when you edit a previous message and import and export in Markdown, HTML, or JSON. |
 | [Plan Mode](https://assistant.posit.co/docs/features/plan-mode/) | A collaborative design phase where the assistant explores the codebase, asks questions, and writes a plan file before changing code. Best for multi-step features, refactors, and unfamiliar codebases. |
-| [Chat Features](https://assistant.posit.co/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off/Low/Medium/High) and optional web search. |
-| [Context Management](https://assistant.posit.co/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto/manual/micro-compaction to keep long conversations within the model's context window. |
+| [Chat Features](https://assistant.posit.co/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off, Low, Medium, and High) and optional web search. |
+| [Context Management](https://assistant.posit.co/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto, manual, and micro-compaction to keep long conversations within the model's context window. |
 | [Permissions & Trust](https://assistant.posit.co/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted) and per-tool permissions configurable in settings. Includes workspace trust prompts when opening projects with `AGENTS.md` and an optional sandbox mode for bash execution. |
 :::
 

--- a/assistant.qmd
+++ b/assistant.qmd
@@ -20,17 +20,11 @@ listing:
         link: "https://opensource.posit.co/topics/artificial-intelligence/"
 ---
 
-::: {.callout-note}
-## Looking for Positron Assistant?
-
-Posit Assistant replaces Positron Assistant as of Positron 2026.07.
-:::
-
-[Posit Assistant](https://assistant.posit.co) is the new AI coding experience available as a preview feature in Positron 2026.04.0 and later. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience.
+[Posit Assistant](https://assistant.posit.co) is the AI coding experience in Positron. It first became available as a preview feature in Positron 2026.04.0, and as of Positron 2026.07 it is the built-in AI experience, replacing Positron Assistant and Databot. For more on how it came to be, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 
 Beyond your active files, selected code, and project structure, Posit Assistant uses context from your interactive data science work, such as your loaded data, plots, and console history. This enables more relevant guidance for core data science workflows, including exploratory analysis, data cleaning, data app development, and modeling.
 
-To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://assistant.posit.co/docs/getting-started/).
+To learn how to enable it and get set up, visit the [Get Started guide](assistant-getting-started.qmd).
 
 ## Features
 
@@ -39,14 +33,14 @@ Posit Assistant has a rich set of features with the highlights listed below.
 ::: {.features-table}
 | Feature | Summary |
 | --- | --- |
-| [Commands](https://posit-dev.github.io/assistant/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions — for example, `/plan`, `/new`, and `/savememory`. |
-| [Skills](https://posit-dev.github.io/assistant/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Built-ins include `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
-| [Memory](https://posit-dev.github.io/assistant/docs/features/memory/) | Persistent project context via an `AGENTS.md` file that captures conventions, architecture, and preferences. The file loads automatically at the start of every conversation in trusted workspaces. |
-| [Conversations](https://posit-dev.github.io/assistant/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion. Includes tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
-| [Plan Mode](https://posit-dev.github.io/assistant/docs/features/plan-mode/) | A collaborative design phase where the assistant explores the codebase, asks questions, and writes a plan file before changing code. Best for multi-step features, refactors, and unfamiliar codebases. |
-| [Chat Features](https://posit-dev.github.io/assistant/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off/Low/Medium/High) and optional web search. |
-| [Context Management](https://posit-dev.github.io/assistant/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto/manual/micro-compaction to keep long conversations within the model's context window. |
-| [Permissions & Trust](https://posit-dev.github.io/assistant/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted) and per-tool permissions configurable in settings. Includes workspace trust prompts when opening projects with `AGENTS.md` and an optional sandbox mode for bash execution. |
+| [Commands](https://assistant.posit.co/docs/features/commands/) | Slash commands typed at the start of a message that trigger special actions — for example, `/plan`, `/new`, and `/savememory`. |
+| [Skills](https://assistant.posit.co/docs/features/skills/) | Specialized knowledge modules that load automatically when relevant to a request, with no manual activation needed. Built-ins include `quarto-authoring`, `shiny-bslib`, and `predictive-modeling-r`, plus user and project-level custom skills. |
+| [Memory](https://assistant.posit.co/docs/features/memory/) | Persistent project context via an `AGENTS.md` file that captures conventions, architecture, and preferences. The file loads automatically at the start of every conversation in trusted workspaces. |
+| [Conversations](https://assistant.posit.co/docs/features/conversations/) | Full conversation history with switching, renaming, and deletion. Includes tree-based branching when you edit a previous message and import/export in Markdown, HTML, or JSON. |
+| [Plan Mode](https://assistant.posit.co/docs/features/plan-mode/) | A collaborative design phase where the assistant explores the codebase, asks questions, and writes a plan file before changing code. Best for multi-step features, refactors, and unfamiliar codebases. |
+| [Chat Features](https://assistant.posit.co/docs/features/chat-features/) | File attachments via drag-and-drop, clipboard paste, or the paperclip, with `@` mentions to reference workspace files. Also includes adjustable thinking effort (Off/Low/Medium/High) and optional web search. |
+| [Context Management](https://assistant.posit.co/docs/features/context-management/) | Automatic inclusion of session info (language, version, variable names and types) when connected to R or Python. Provides a token counter with detailed breakdown and auto/manual/micro-compaction to keep long conversations within the model's context window. |
+| [Permissions & Trust](https://assistant.posit.co/docs/features/permissions/) | Three approval modes (Normal, YOLO, Restricted) and per-tool permissions configurable in settings. Includes workspace trust prompts when opening projects with `AGENTS.md` and an optional sandbox mode for bash execution. |
 :::
 
 ## Learn more

--- a/databot.qmd
+++ b/databot.qmd
@@ -1,14 +1,14 @@
 ---
 title: "Databot"
-description: "Databot is deprecated. The AI chat and coding experience in Positron is now Posit Assistant."
+description: "Databot is deprecated. The AI chat and coding experience in Positron is Posit Assistant."
 ---
 
 ::: {.callout-warning}
 ## Databot is deprecated
 
-Databot, the experimental exploratory data analysis assistant, has been deprecated as of Positron 2026.07. The AI chat and coding experience in Positron is now [Posit Assistant](https://assistant.posit.co). This page remains in place for folks still using Databot.
+Databot, the experimental exploratory data analysis assistant, is deprecated as of Positron 2026.07. The AI chat and coding experience in Positron is [Posit Assistant](https://assistant.posit.co). This page remains in place for folks still using Databot.
 
-If you're getting started, use Posit Assistant instead and see the [Posit Assistant documentation](https://assistant.posit.co) to get set up. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
+If you are on Positron 2026.07 or later, see the [Posit Assistant documentation](https://assistant.posit.co) to get set up with Posit Assistant. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 :::
 
 Databot is an AI assistant designed to dramatically accelerate exploratory data analysis for data scientists fluent in Python or R, allowing them to do in minutes what might usually take hours. It’s a complement to the data scientist, not a replacement.

--- a/databot.qmd
+++ b/databot.qmd
@@ -1,14 +1,14 @@
 ---
 title: "Databot"
-description: "Experimental AI assistant for exploratory data analysis in Python and R. Accelerate insights by letting AI write and execute analysis code for you."
+description: "Databot is deprecated. The AI chat and coding experience in Positron is now Posit Assistant."
 ---
 
-::: {.callout-important}
+::: {.callout-warning}
+## Databot is deprecated
 
-Databot was previously experimental and available in research preview, but is being deprecated in favor of Posit Assistant.
+Databot, the experimental exploratory data analysis assistant, has been deprecated as of Positron 2026.07. The AI chat and coding experience in Positron is now [Posit Assistant](https://assistant.posit.co). This page remains in place for folks still using Databot.
 
-[Posit Assistant](https://pos.it/assistant) is a new AI coding experience currently available as a preview feature. Posit Assistant brings together the capabilities of Positron Assistant and Databot into a unified experience. To learn how to enable it and get set up, visit the [Posit Assistant documentation](https://pos.it/assistant-docs).
-
+If you're getting started, use Posit Assistant instead and see the [Posit Assistant documentation](https://assistant.posit.co) to get set up. For background on this change, see [The history of Posit's data science agents](https://opensource.posit.co/blog/2026-06-11_history-of-posit-data-science-agents).
 :::
 
 Databot is an AI assistant designed to dramatically accelerate exploratory data analysis for data scientists fluent in Python or R, allowing them to do in minutes what might usually take hours. It’s a complement to the data scientist, not a replacement.
@@ -39,7 +39,7 @@ To acknowledge the research preview status, find [`databot.researchPreviewAcknow
 
 OR
 
-* In Positron, open the Command Palette {{< kbd mac=Command-Shift-P win=Ctrl-Shift-P linux=Ctrl-Shift-P >}} and run _Open User Settings_.  
+* In Positron, open the Command Palette {{< kbd mac=Command-Shift-P win=Ctrl-Shift-P linux=Ctrl-Shift-P >}} and run _Open User Settings_.
 * In the search bar, enter "Databot".
 * You will see **Databot: Research Preview Acknowledgment**. In the text box, enter "Acknowledged".
 
@@ -47,7 +47,7 @@ OR
 
 In Positron, open the Command Palette {{< kbd mac=Command-Shift-P win=Ctrl-Shift-P linux=Ctrl-Shift-P >}} and run _Open Databot_.
 
-### Enable Positron Assistant 
+### Enable Positron Assistant
 
 If [Positron Assistant](assistant.qmd) is not yet enabled, you will see the following message in the Databot panel: “To use Databot, enable Positron Assistant and Anthropic provider."
 
@@ -65,7 +65,7 @@ For this step, you will need an Anthropic API key.
 
 In section 3 of the dialog box, **Add Anthropic provider**, select the button labeled **Click here**. This will open a dialog box to configure Language Model Providers.
 
-* Select **Anthropic** and enter your API key.  
+* Select **Anthropic** and enter your API key.
 
 Close the dialog boxes. Databot is now ready to use!
 
@@ -85,17 +85,17 @@ For more information about Databot, please review the [Databot introduction blog
 
 ### Are you sure it’s not for people who aren’t comfortable writing their own code? Why not?
 
-* As far as we can tell, today’s models cannot be trusted to do open-ended data exploration without at least occasionally making mistakes. That’s why Databot’s user experience is intentionally code-forward, and a Databot analysis is not truly complete until the user has carefully reviewed important subsets of the model-generated code. 
+* As far as we can tell, today’s models cannot be trusted to do open-ended data exploration without at least occasionally making mistakes. That’s why Databot’s user experience is intentionally code-forward, and a Databot analysis is not truly complete until the user has carefully reviewed important subsets of the model-generated code.
 * Learn more at [Databot is not a flotation device](https://posit.co/blog/databot-is-not-a-flotation-device).
 
 ### How is Databot different from Positron Assistant?
 
-* [Positron Assistant](assistant.qmd) is an _AI coding assistant_; it helps you write code or modify code on disk and can execute arbitrary code in Agent mode. 
+* [Positron Assistant](assistant.qmd) is an _AI coding assistant_; it helps you write code or modify code on disk and can execute arbitrary code in Agent mode.
 * Databot is a purpose-built _exploratory data analysis_ agent. It writes and executes its own code on the fly to help you understand your data. It doesn’t care very much about the code you’ve already written.
 
 ### Can I use Databot for machine learning, Shiny apps, ETL pipelines, or other tasks?
 
-* Databot will attempt other data-oriented tasks if prompted, but it was primarily designed for exploratory data analysis. The user experience is aimed at rapid iteration of short code snippets that execute quickly, and assumes that insights, not code, is the primary goal. 
+* Databot will attempt other data-oriented tasks if prompted, but it was primarily designed for exploratory data analysis. The user experience is aimed at rapid iteration of short code snippets that execute quickly, and assumes that insights, not code, is the primary goal.
 
 ### What data sources can Databot use? Will it work with databases? Parquet files on S3?
 
@@ -108,4 +108,3 @@ For more information about Databot, please review the [Databot introduction blog
 ### Are OpenAI, Gemini, and other models supported?
 
 * Those providers are not supported. We hope to add support once they are exposed in Positron Assistant.
-

--- a/release-notes/release-2026-05.qmd
+++ b/release-notes/release-2026-05.qmd
@@ -54,7 +54,7 @@ The Positron Notebook Editor for `.ipynb` files is officially moving from alpha 
 
 This release introduces two new AI options: Posit Assistant and Posit AI.
 
-- You may have tried some of our previous experiments for AI code assistance available in Positron, Positron Assistant and/or Databot. We are now migrating to a more data-science-specific, holistic, unified approach to AI chat, built on the same Posit Assistant interface that [we recently brought to RStudio](https://posit.co/blog/introducing-ai-in-rstudio/). Instead of switching between tools, you get code generation, next edit suggestions, chat, and agentic tools all in one place. [Learn how to get started](https://posit-dev.github.io/assistant/docs/downloads/positron/).
+- You may have tried some of our previous experiments for AI code assistance available in Positron, Positron Assistant and/or Databot. We are now migrating to a more data-science-specific, holistic, unified approach to AI chat, built on the same Posit Assistant interface that [we recently brought to RStudio](https://posit.co/blog/introducing-ai-in-rstudio/). Instead of switching between tools, you get code generation, next edit suggestions, chat, and agentic tools all in one place. [Learn how to get started](https://assistant.posit.co/docs/downloads/positron/).
 
 - [Posit AI](https://posit.co/products/ai) is a new, optional model provider service available to use with Posit Assistant. Posit AI is a subscription priced at $20/month for individual users; both Positron and Posit Assistant remain free to use. [Learn how to sign up for an account](https://posit.co/products/ai).
 

--- a/release-notes/release-2026-06.qmd
+++ b/release-notes/release-2026-06.qmd
@@ -22,7 +22,7 @@ Welcome to the 2026.06.0 release of Positron!
 
 #### Posit Assistant
 
-Last release we introduced [Posit Assistant](https://pos.it/assistant), our unified, data-science-focused approach to AI assistance. This release continues that work, and we want to give you advance notice that the older Positron Assistant will be deprecated in the next release. If you are still using Positron Assistant, we encourage you to migrate to Posit Assistant now. As a first step, the `positron.assistant.enable` setting is deprecated in favor of [`assistant.enabled`](positron://settings/assistant.enabled), and the Positron Assistant welcome view now points you to Posit Assistant. 
+Last release we introduced [Posit Assistant](https://assistant.posit.co), our unified, data-science-focused approach to AI assistance. This release continues that work, and we want to give you advance notice that the older Positron Assistant will be deprecated in the next release. If you are still using Positron Assistant, we encourage you to migrate to Posit Assistant now. As a first step, the `positron.assistant.enable` setting is deprecated in favor of [`assistant.enabled`](positron://settings/assistant.enabled), and the Positron Assistant welcome view now points you to Posit Assistant. 
 
 Posit Assistant supports the same broad set of providers as Positron Assistant, along with the Posit AI model provider and new experimental support for Google Vertex. [Learn more](https://youtu.be/Y9P2nlFXKnQ) about the differences between the new Posit Assistant and the older Positron Assistant.
 


### PR DESCRIPTION
- addresses most of https://github.com/posit-dev/positron/issues/14333
    - I decided not to remove the Databot docs as that url is referenced in blog posts and the Posit Assistant docs, so I updated it to use similar wording as the deprecated Positron Assistant pages
    - I am going to itemize the features in a separate PR, as I think I'll need to reorganize the side bar a bit more to accommodate e.g., git commit messages, console fix&explain, maybe move Notebooks AI features into this section and out of the Notebooks page, etc.

Changes
- Reworked the sidebar; renamed the "AI Tools" section to "AI Features" with Posit Assistant up top, and moved Positron Assistant and Databot under it both labelled "(deprecated)".
- Deprecated Positron Assistant and Databot — swapped their callouts to deprecation warnings that point folks to Posit Assistant (as of Positron 2026.07), while keeping the pages around for people on older builds.
- Use Positron's get started docs page instead of linking out to Posit Assistant's (addresses Jon's comment in the issue)
- Updated all the assistant links from from pos.it/assistant-docs and posit-dev.github.io/assistant over to assistant.posit.co.
- Expanded the provider privacy/terms page — added Posit AI, OpenAI, Snowflake Cortex, DeepSeek, Google Gemini, and a Custom Provider entry, and made the general wording provider-agnostic instead of calling out just Anthropic/Copilot.
- Linked out to the "history of Posit's data science agents" blog post for background.
- Various wording and link cleanup/updates