### PR TITLE
Add new Quarto profile for dev documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /env/
 /_site/
 /_site-workbench/
+/_site-dailies/
 /.venv/
 /.luarc.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ The site has two Quarto profiles defined in `_quarto.yml`:
 - **positron** (`_quarto-positron.yml`): Full public documentation site, outputs to `_site/`
 - **workbench** (`_quarto-workbench.yml`): Subset for Workbench bundled docs, excludes download/install pages, outputs to `_site-workbench/`
 
-New pages will likely need to be added to both profile config files.
+There is also a **dailies** overlay (`_quarto-dailies.yml`) for the dev docs served at positron.posit.co/dailies, built from `main` on every merge. It is not a standalone profile: activate it together with positron, listed first so its values win for scalar options (`QUARTO_PROFILE=dailies,positron quarto render`). It only contains deltas from the positron profile (output to `_site-dailies/`, `/dailies` site URL, an announcement banner, a `NEXT_RELEASE` footer version, and a noindex meta tag), so it has no navbar/sidebar config of its own.
+
+New pages will likely need to be added to both the positron and workbench profile config files (not the dailies overlay).
 
 **Videos are excluded from the workbench profile.** A Lua filter (`_extensions/video-filter/`) automatically removes video elements when building for workbench. Use the standard `{{< video >}}` shortcode; videos will appear in the public site but not in the workbench bundle.
 

--- a/_quarto-dailies.yml
+++ b/_quarto-dailies.yml
@@ -1,0 +1,28 @@
+# Overlay profile for the dev docs served at positron.posit.co/dailies
+# Not a standalone profile: activate together with positron, with dailies
+# listed first so its values take priority for scalar options:
+#   QUARTO_PROFILE=dailies,positron quarto render
+
+project:
+  output-dir: _site-dailies
+
+website:
+  site-url: https://positron.posit.co/dailies
+  announcement:
+    icon: cone-striped
+    dismissable: false
+    type: danger
+    position: below-navbar
+    content: |
+      You are viewing the development version of Positron documentation for the dailies ({{< env NEXT_RELEASE >}}).
+      Some features described here are not yet available in the latest regular release.
+      [Go to the released documentation](https://positron.posit.co/).
+
+  page-footer:
+    center: "Positron {{< env NEXT_RELEASE >}} (development version)"
+
+format:
+  html:
+    include-in-header:
+      - text: |
+          <meta name="robots" content="noindex">


### PR DESCRIPTION
This is step 1 of moving positron.posit.co from Netlify to GitHub Pages with a dev docs version served at `/dailies` (see https://github.com/posit-dev/positron-builds/issues/1127 for the full plan). This PR only adds the Quarto configuration for the dailies variant of the site; nothing builds or deploys it yet.

## Changes

- **New `_quarto-dailies.yml` overlay profile.** It is not a standalone profile: it activates together with the positron profile, listed first so its values win for scalar options:

  ```bash
  QUARTO_PROFILE=dailies,positron quarto preview
  ```

  It only contains deltas from the positron profile:
  - Output goes to `_site-dailies/`
  - `site-url` becomes `https://positron.posit.co/dailies` so canonical URLs and the sitemap resolve under the prefix
  - A non-dismissable announcement banner (danger styling, striped cone icon) below the navbar explaining that these are docs for the development version ({{< env NEXT_RELEASE >}}) and linking back to the released docs
  - The page footer shows `Positron <NEXT_RELEASE> (development version)` instead of `RELEASE_VERSION`
  - A `<meta name="robots" content="noindex">` tag so `/dailies` pages stay out of search engines
- **`.gitignore`**: added `/_site-dailies/`
- **`CLAUDE.md`**: documented the new overlay in the Multi-Profile Build System section, including that new pages do not need to be added to it (only to the positron and workbench configs)

## Verification

Render or preview the full site with `QUARTO_PROFILE=dailies,positron` and confirmed in the output: the banner renders with `NEXT_RELEASE` resolved, the noindex tag is present alongside the positron profile's existing header includes, the footer shows the development version, and all sitemap URLs resolve under `/dailies/`. Also re-rendered with the default profile and confirmed no leakage: no banner, no noindex, footer still shows `RELEASE_VERSION`.

## Not covered yet (later steps)

- CI workflow to build the site and publish `/dailies` to `gh-pages` on merges to `main`
- Netlify PR deploy previews driven from CI
- Publishing the release site to the `gh-pages` root from the docs release workflow
- Redirect stubs for GitHub Pages and the DNS cutover
