### PR TITLE
Add build-and-deploy CI workflow (PR previews + dailies publish)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,119 @@
+name: Build and deploy
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded runs for PRs; let main-branch publishes finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Render docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Get Quarto version
+        id: get-quarto-version
+        run: |
+          QUARTO_VERSION=$(grep 'version = ' netlify.toml | sed 's/.*version = "v\?\([^"]*\)".*/\1/')
+          echo "quarto_version=${QUARTO_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: ${{ steps.get-quarto-version.outputs.quarto_version }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # No R or Python needed: computed pages are served from committed _freeze.
+      - name: Render public Positron docs
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          QUARTO_PROFILE: positron
+
+      - name: Upload _site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: _site
+
+      # Dailies (dev docs) are only published from main, so only build them there.
+      - name: Render dailies docs
+        if: github.event_name == 'push'
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          QUARTO_PROFILE: dailies,positron
+
+      - name: Upload _site-dailies artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-dailies
+          path: _site-dailies
+
+  preview:
+    name: Deploy PR preview to Netlify
+    needs: build
+    # PRs only, and skip fork PRs since they can't access secrets.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - name: Download _site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: _site
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: _site
+          production-deploy: false
+          deploy-message: "Preview for PR #${{ github.event.number }}"
+          alias: pr-${{ github.event.number }}
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          github-deployment-environment: preview
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 5
+
+  publish-dailies:
+    name: Publish dailies to gh-pages
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download _site-dailies artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-dailies
+          path: _site-dailies
+
+      # keep_files preserves the released site at the root (and CNAME); this job
+      # only ever touches the dailies/ subdirectory.
+      - name: Publish to gh-pages under /dailies
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _site-dailies
+          destination_dir: dailies
+          keep_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 **/*.quarto_ipynb
 __pycache__/
+
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
This PR adds a new "Build and deploy" GitHub Actions workflow (`.github/workflows/build-and-deploy.yml`), the next piece in moving `positron.posit.co` off Netlify production and onto GitHub Pages, with dev docs served under `/dailies`. This is Step 2 of posit-dev/positron-builds#1127.

The workflow has three jobs:

- **`build`** (on PRs and pushes to `main`): reads the pinned Quarto version, sets up Quarto, renders the `positron` profile, and uploads `_site` as an artifact. On pushes to `main` it also renders the `dailies,positron` overlay and uploads `_site-dailies`. No R or Python is needed in CI because computed pages are served from the committed `_freeze`.
- **`preview`** (PRs only, skipped for fork PRs since they can't access secrets): downloads the `_site` artifact and deploys it to Netlify under a `pr-<number>` alias via `nwtgck/actions-netlify`, which also creates a GitHub Deployment and posts the preview URL as a PR comment.
- **`publish-dailies`** (pushes to `main` only): downloads `_site-dailies` and publishes it to the `gh-pages` branch under `dailies/` with `keep_files: true`, so the released site at the root (and `CNAME`) stays intact.

I need to confirm we have `NETLIFY_SITE_ID` and `NETLIFY_AUTH_TOKEN` repository secrets, pointing at a dedicated Netlify preview site (not production). Until then the `preview` job will fail on PRs.

## Scope and safety

This is still in the prep and early stages of what's outlined in the tracking issue, so we'll land the CI workflow and PR previews while Netlify continues to build and serve production. Nothing user-facing changes at all yet:

- Netlify still builds and serves positron.posit.co.
- The `gh-pages` branch is not served by anything until GitHub Pages is enabled for it (a later phase), so `publish-dailies` just quietly maintains the branch for now.

## Notes

- `keep_files: true` preserves the root site but does not prune: a page removed from the dailies build will linger in `gh-pages/dailies/` on later runs. This is the tradeoff noted in the issue (peaceiris has no "clean only this subdirectory" mode).
- The Quarto version is still read from `netlify.toml` using the same grep already used by `release-docs-bundles.yml`, to keep one source of truth for now. Hoisting that pin into a dedicated file is Step 3.
- After merging, let's plan to watch a few PRs (preview parity) and a few merges (clean dailies publishes) before starting Step 3.

Addresses part of posit-dev/positron-builds#1127.
