### PR TITLE
update github copilot auth, config docs and settings

### DIFF
--- a/ai-configuration.qmd
+++ b/ai-configuration.qmd
@@ -29,7 +29,7 @@ To disable a specific feature without affecting others:
 |---------|------------------|
 | [`assistant.enabled`](positron://settings/assistant.enabled) | [Posit Assistant](https://assistant.posit.co) (set to `false` to disable) |
 | [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) | [Posit AI NES](assistant-completions.qmd#posit-ai-nes) (set to `{ "*": false }` to disable) |
-| [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot Ghost-text Completions and Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable both ) |
+| [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot ghost-text completions and Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable both) |
 | [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) | Built-in [GitHub Copilot Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `false` to disable) |
 | [`notebook.ai.enabled`](positron://settings/notebook.ai.enabled) | [Notebook AI features](positron-notebook-editor.qmd#ai-integration) (set to `false` to disable) |
 | [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) | [Console Fix & Explain](managing-interpreters.qmd#console-fix-and-explain) (set to `false` to disable) |
@@ -37,6 +37,6 @@ To disable a specific feature without affecting others:
 
 ## GitHub Copilot chat {#github-copilot-chat}
 
-Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. This does not affect GitHub Copilot [ghost-text completions or next edit suggestions (NES)](assistant-completions.qmd#github-copilot). Both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
+Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. This does not affect GitHub Copilot [ghost-text completions or Next Edit Suggestions (NES)](assistant-completions.qmd#github-copilot). Both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
 
 To bring back the built-in GitHub Copilot chat UI, set [`chat.disableAIFeatures`](positron://settings/chat.disableAIFeatures) to `false`.

--- a/ai-configuration.qmd
+++ b/ai-configuration.qmd
@@ -41,6 +41,6 @@ To disable a specific feature without affecting others:
 
 ## GitHub Copilot chat {#github-copilot-chat}
 
-Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. However, GitHub Copilot [ghost-text completions or Next Edit Suggestions (NES)](assistant-completions.qmd#github-copilot) both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
+Positron hides the GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. To show the GitHub Copilot chat UI again, set [`chat.disableAIFeatures`](positron://settings/chat.disableAIFeatures) to `false`.
 
-To bring back the built-in GitHub Copilot chat UI, set [`chat.disableAIFeatures`](positron://settings/chat.disableAIFeatures) to `false`.
+Regardless of that setting, GitHub Copilot [ghost-text completions and NES](assistant-completions.qmd#github-copilot) are available once you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).

--- a/ai-configuration.qmd
+++ b/ai-configuration.qmd
@@ -5,6 +5,10 @@ description: "Configure the AI features in Positron, including turning individua
 
 Once you have [set up a language model provider](assistant-getting-started.qmd), you can configure how AI features behave in Positron.
 
+::: {.callout-note}
+[`ai.enabled`](positron://settings/ai.enabled) is `true` by default, but AI functionality is only active once you have authenticated with a language model provider.
+:::
+
 ## Turn features on or off
 
 You can turn off individual features or disable all AI features at once.

--- a/ai-configuration.qmd
+++ b/ai-configuration.qmd
@@ -29,7 +29,14 @@ To disable a specific feature without affecting others:
 |---------|------------------|
 | [`assistant.enabled`](positron://settings/assistant.enabled) | [Posit Assistant](https://assistant.posit.co) (set to `false` to disable) |
 | [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) | [Posit AI NES](assistant-completions.qmd#posit-ai-nes) (set to `{ "*": false }` to disable) |
-| [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot Code Completions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable) |
+| [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot Ghost-text Completions and Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable both ) |
+| [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) | Built-in [GitHub Copilot Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `false` to disable) |
 | [`notebook.ai.enabled`](positron://settings/notebook.ai.enabled) | [Notebook AI features](positron-notebook-editor.qmd#ai-integration) (set to `false` to disable) |
 | [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) | [Console Fix & Explain](managing-interpreters.qmd#console-fix-and-explain) (set to `false` to disable) |
 | [`git.suggestions.enabled`](positron://settings/git.suggestions.enabled) | [Git commit messages](git.qmd#generate-commit-messages) (set to `false` to disable) |
+
+## GitHub Copilot chat {#github-copilot-chat}
+
+Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. This does not affect GitHub Copilot [ghost-text completions or next edit suggestions (NES)](assistant-completions.qmd#github-copilot). Both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
+
+To bring back the built-in GitHub Copilot chat UI, set [`chat.disableAIFeatures`](positron://settings/chat.disableAIFeatures) to `false`.

--- a/ai-configuration.qmd
+++ b/ai-configuration.qmd
@@ -30,13 +30,13 @@ To disable a specific feature without affecting others:
 | [`assistant.enabled`](positron://settings/assistant.enabled) | [Posit Assistant](https://assistant.posit.co) (set to `false` to disable) |
 | [`nextEditSuggestions.enabled`](positron://settings/nextEditSuggestions.enabled) | [Posit AI NES](assistant-completions.qmd#posit-ai-nes) (set to `{ "*": false }` to disable) |
 | [`github.copilot.enable`](positron://settings/github.copilot.enable) | [GitHub Copilot ghost-text completions and Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `{ "*": false }` to disable both) |
-| [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) | Built-in [GitHub Copilot Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `false` to disable) |
+| [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) | [GitHub Copilot Next Edit Suggestions](assistant-completions.qmd#github-copilot) (set to `false` to disable) |
 | [`notebook.ai.enabled`](positron://settings/notebook.ai.enabled) | [Notebook AI features](positron-notebook-editor.qmd#ai-integration) (set to `false` to disable) |
 | [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) | [Console Fix & Explain](managing-interpreters.qmd#console-fix-and-explain) (set to `false` to disable) |
 | [`git.suggestions.enabled`](positron://settings/git.suggestions.enabled) | [Git commit messages](git.qmd#generate-commit-messages) (set to `false` to disable) |
 
 ## GitHub Copilot chat {#github-copilot-chat}
 
-Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. This does not affect GitHub Copilot [ghost-text completions or Next Edit Suggestions (NES)](assistant-completions.qmd#github-copilot). Both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
+Positron hides the built-in GitHub Copilot chat interface by default, since Posit Assistant is the default chat experience in Positron. However, GitHub Copilot [ghost-text completions or Next Edit Suggestions (NES)](assistant-completions.qmd#github-copilot) both stay available whenever you [sign in to GitHub Copilot as a provider](assistant-providers.qmd#github-copilot).
 
 To bring back the built-in GitHub Copilot chat UI, set [`chat.disableAIFeatures`](positron://settings/chat.disableAIFeatures) to `false`.

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -80,9 +80,9 @@ GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless y
 
 If you have enabled GitHub Copilot as a model provider, you can disable completions by doing any of the following:
 
-- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects other features and extensions that rely on the GitHub account. Without a signed-in GitHub account, GitHub Copilot Chat cannot be used, and GitHub Copilot cannot provide completions, Next Edit Suggestions, or be used as a provider for Posit Assistant. 
 - Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to `{ "*": false }` to disable both ghost-text completions and Next Edit Suggestions, without having to sign out. To disable only some languages, set those entries to `false` instead of `*`.
 - Set [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) to `false` to disable Next Edit Suggestions on their own, while keeping ghost-text completions on.
+- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects other features and extensions that rely on the GitHub account. Without a signed-in GitHub account, GitHub Copilot Chat cannot be used, and GitHub Copilot cannot provide completions, Next Edit Suggestions, or be used as a provider for Posit Assistant.
 
 To exclude specific files from Copilot completions regardless of language, use the shared [`aiExcludes`](#shared-settings) setting.
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -66,6 +66,8 @@ To exclude specific files from Posit AI NES regardless of language, [use the sha
 
 When using GitHub Copilot as your completions provider, code completions appear as ghost text at the cursor position as you type. To learn more, visit the GitHub Copilot [inline suggestions](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions#_getting-your-first-suggestions) documentation.
 
+GitHub Copilot also has its own Next Edit Suggestions, separate from the ghost-text completions described here and from [Posit AI NES](#posit-ai-nes). It is available whenever you sign in to GitHub Copilot as a provider.
+
 ### Enable
 
 GitHub Copilot completions are enabled by default once you have [signed in to the GitHub Copilot provider](assistant-providers.qmd#github-copilot). No additional setting changes are required.
@@ -76,12 +78,11 @@ GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless y
 
 ### Disable
 
-To disable GitHub Copilot completions, do any of the following:
+Choose the option that matches what you want to disable:
 
-- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects chat and other features that rely on the account.
-- Run the _Positron Assistant: Toggle (Enable/Disable) Completions_ command to toggle Copilot completions for the current language. This command updates [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) for the active language.
-- Set [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) to `{ "*": false }` to disable Copilot completions everywhere. To disable only some languages, set those entries to `false`.
-- Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to disable completions at the upstream GitHub Copilot extension level.
+- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. Without a signed-in account, GitHub Copilot cannot provide completions, Next Edit Suggestions, or chat. This also affects other features that rely on the account.
+- Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to `{ "*": false }` to disable both ghost-text completions and Next Edit Suggestions, without having to sign out. To disable only some languages, set those entries to `false` instead of `*`.
+- Set [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) to `false` to disable Next Edit Suggestions on their own, while keeping ghost-text completions on.
 
 To exclude specific files from Copilot completions regardless of language, use the shared [`aiExcludes`](#shared-settings) setting.
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -70,7 +70,7 @@ GitHub Copilot also has its own Next Edit Suggestions, separate from the ghost-t
 
 ### Enable
 
-GitHub Copilot completions are enabled by default once you have [signed in to the GitHub Copilot provider](assistant-providers.qmd#github-copilot). No additional setting changes are required.
+GitHub Copilot completions are enabled after you [sign in to the GitHub Copilot provider](assistant-providers.qmd#github-copilot). No additional setting changes are required.
 
 ### Restrict to specific languages
 
@@ -78,7 +78,7 @@ GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless y
 
 ### Disable
 
-Choose the option that matches what you want to disable:
+If you have enabled GitHub Copilot as a model provider, you can disable completions by doing any of the following:
 
 - Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects other features and extensions that rely on the GitHub account. Without a signed-in GitHub account, GitHub Copilot Chat cannot be used, and GitHub Copilot cannot provide completions, Next Edit Suggestions, or be used as a provider for Posit Assistant. 
 - Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to `{ "*": false }` to disable both ghost-text completions and Next Edit Suggestions, without having to sign out. To disable only some languages, set those entries to `false` instead of `*`.

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -80,7 +80,7 @@ GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless y
 
 Choose the option that matches what you want to disable:
 
-- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. Without a signed-in account, GitHub Copilot cannot provide completions, Next Edit Suggestions, or chat. This also affects other features that rely on the account.
+- Sign out of GitHub in Positron via the Accounts menu or the _Accounts: Manage Accounts_ command. This also affects other features and extensions that rely on the GitHub account. Without a signed-in GitHub account, GitHub Copilot Chat cannot be used, and GitHub Copilot cannot provide completions, Next Edit Suggestions, or be used as a provider for Posit Assistant. 
 - Set [`github.copilot.enable`](positron://settings/github.copilot.enable) to `{ "*": false }` to disable both ghost-text completions and Next Edit Suggestions, without having to sign out. To disable only some languages, set those entries to `false` instead of `*`.
 - Set [`github.copilot.nextEditSuggestions.enabled`](positron://settings/github.copilot.nextEditSuggestions.enabled) to `false` to disable Next Edit Suggestions on their own, while keeping ghost-text completions on.
 

--- a/assistant-completions.qmd
+++ b/assistant-completions.qmd
@@ -74,7 +74,7 @@ GitHub Copilot completions are enabled after you [sign in to the GitHub Copilot 
 
 ### Restrict to specific languages
 
-GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`positron.assistant.inlineCompletions.enable`](positron://settings/positron.assistant.inlineCompletions.enable) setting to change which languages Copilot completions apply to.
+GitHub Copilot completions skip `plaintext`, `markdown`, and `scminput` unless you configure otherwise. Use the [`github.copilot.enable`](positron://settings/github.copilot.enable) setting to change which languages Copilot completions apply to.
 
 ### Disable
 

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -134,8 +134,12 @@ Use the model name and deployment identifier from your Foundry resource for each
 - **Account:** a GitHub account with Copilot enabled
 - **Authentication:** sign in through your browser with OAuth
 
+To sign in, use the _Authentication: Configure Language Model Providers_ command, select GitHub Copilot, and sign in. If you already have a GitHub session from another extension, this asks you to confirm reusing it for Assistant; otherwise it starts a new browser sign-in flow.
+
+To sign out, use the {{< fa circle-user >}} **Accounts** icon or run the _Accounts: Manage Accounts_ command. Unlike signing in, this signs you out for all features in Positron that use your GitHub account, such as the Git or GitHub Pull Requests extensions.
+
 ::: {.callout-note}
-You can also sign in to GitHub via the {{< fa circle-user >}} **Accounts** icon in the Activity Bar. To sign out, use the Accounts icon or run the _Accounts: Manage Accounts_ command. The Accounts section manages your GitHub authentication for all extensions that use GitHub, not just AI features.
+Signing in to GitHub through the {{< fa circle-user >}} **Accounts** icon in the Activity Bar, for example for Git or GitHub Pull Requests, does not sign you in to GitHub Copilot for AI features.
 :::
 
 ### Get GitHub Copilot access

--- a/assistant-providers.qmd
+++ b/assistant-providers.qmd
@@ -134,12 +134,12 @@ Use the model name and deployment identifier from your Foundry resource for each
 - **Account:** a GitHub account with Copilot enabled
 - **Authentication:** sign in through your browser with OAuth
 
-To sign in, use the _Authentication: Configure Language Model Providers_ command, select GitHub Copilot, and sign in. If you already have a GitHub session from another extension, this asks you to confirm reusing it for Assistant; otherwise it starts a new browser sign-in flow.
+To sign in, use the _Authentication: Configure Language Model Providers_ command, select GitHub Copilot, and sign in. If you already have a GitHub session from another extension, this asks you to confirm reusing it for Assistant. Otherwise, it starts a new browser sign-in flow.
 
 To sign out, use the {{< fa circle-user >}} **Accounts** icon or run the _Accounts: Manage Accounts_ command. Unlike signing in, this signs you out for all features in Positron that use your GitHub account, such as the Git or GitHub Pull Requests extensions.
 
 ::: {.callout-note}
-Signing in to GitHub through the {{< fa circle-user >}} **Accounts** icon in the Activity Bar, for example for Git or GitHub Pull Requests, does not sign you in to GitHub Copilot for AI features.
+Signing in to GitHub through the {{< fa circle-user >}} **Accounts** menu in the Activity Bar does not sign you in to GitHub Copilot for AI features. This applies even when you use the Accounts menu for other extensions, such as Git or GitHub Pull Requests.
 :::
 
 ### Get GitHub Copilot access


### PR DESCRIPTION
- Closes https://github.com/posit-dev/positron/issues/14795
- I decided not to cover `positron.assistant.provider.githubCopilot.enable` because the setting will soon be deprecated