### PR TITLE
Fix where we get the GH token

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -88,10 +88,11 @@ jobs:
           enable-pull-request-comment: true
           enable-commit-comment: false
           github-deployment-environment: preview
+          # The action reads the token from this input, not from env.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 5
 
   publish-dailies:


### PR DESCRIPTION
This fixes the PR preview job in `build-and-deploy.yml` so it posts the Netlify preview comment and creates the GitHub Deployment entry. The Netlify deploy itself was already working, but the two GitHub-facing conveniences were silently being skipped.

## Why they were skipped

The `nwtgck/actions-netlify` action reads the GitHub token from a `with: github-token:` input (via `core.getInput('github-token')`), not from an environment variable. Our workflow was passing it as `env: GITHUB_TOKEN:` instead, so the action saw an empty token and hit an early `return` right after deploying, before the PR-comment and GitHub-Deployment code ever ran.

That matches what we saw on PR #419 where the deploy succeeded and logged `🚀 Deployed on https://pr-419--positron-website-preview.netlify.app`, then the job ended with no comment, no deployment, and no error. (The Netlify deploy works regardless because `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` are read straight from `process.env`.)

This was not a permissions problem as `pull-requests: write` and `deployments: write` were both already granted. The token just never reached the code that uses them.

## Change

Move `github-token: ${{ secrets.GITHUB_TOKEN }}` from `env:` into the action's `with:` block, and drop the now-unused `GITHUB_TOKEN` env entry. The two Netlify variables stay in `env:`.

## Validation

The fix only takes effect on workflow runs triggered after it lands, so we will confirm on the next PR (or a new commit to an existing PR) that:

- The `pr-<n>--positron-website-preview.netlify.app` preview comment posts.
- A GitHub Deployment entry appears for the PR.
- Pushing another commit updates the same comment rather than duplicating it (the action's `overwrites-pull-request-comment` defaults to true).

Related to posit-dev/positron-builds#1127
