### PR TITLE
Fetch LFS content so videos render as real files, not pointer stubs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Fetch LFS content so videos render as real files, not pointer stubs.
+          lfs: true
 
       - name: Get Quarto version
         id: get-quarto-version


### PR DESCRIPTION
The build job checked out with `actions/checkout@v4` and no `lfs: true`, so every `_site/videos/*.mp4` was a Git LFS pointer stub instead of the real file. The rendered HTML references these locally, so anything served from the CI build (PR previews, and dailies on gh-pages) shipped broken videos. Production Netlify was unaffected because its own build resolves LFS.

Adding `lfs: true` to the checkout fetches the real video files. Addresses part of https://github.com/posit-dev/positron-builds/issues/1127.
