### PR TITLE
feat: publish slim LLM-only docs bundles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,17 @@ jobs:
         with:
           args: "--no-progress --verbose './**/*.qmd' './_redirects'"
           fail: true
+
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Shellcheck
+        run: shellcheck scripts/*.sh
+
+      # The bundle script otherwise only runs during a release, where a guard bug
+      # surfaces as a failed release rather than a failed PR.
+      - name: Test the LLM docs bundle build
+        run: scripts/test-build-llms-bundle.sh

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -180,6 +180,10 @@ jobs:
         with:
           tag_name: ${{ steps.get-version.outputs.release_version }}
           name: ${{ steps.get-version.outputs.release_version }}
+          # Only a `releases` run may claim the repo's "Latest" badge. A staging or
+          # dailies run creates a real release too, and without this a throwaway
+          # test version would display as Latest until someone deleted it.
+          prerelease: ${{ inputs.release_channel != 'releases' }}
           body: |
             Documentation for https://github.com/posit-dev/positron/releases/tag/${{ steps.get-version.outputs.release_version }}
           files: |

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -108,11 +108,6 @@ jobs:
           cd ../_site-workbench
           zip -r ../positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip .
 
-      - name: Create slim LLM docs bundles
-        run: |
-          scripts/build-llms-bundle.sh _site positron "${{ steps.get-version.outputs.release_version }}"
-          scripts/build-llms-bundle.sh _site-workbench workbench "${{ steps.get-version.outputs.release_version }}"
-
       - name: Delete existing release
         if: ${{ inputs.overwrite }}
         env:
@@ -153,6 +148,11 @@ jobs:
           S3_PREFIX="s3://posit-positron-downloads/positron/${{ inputs.release_channel }}/docs"
           aws s3 cp "positron-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
           aws s3 cp "positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
+
+      - name: Create slim LLM docs bundles
+        run: |
+          scripts/build-llms-bundle.sh _site positron "${{ steps.get-version.outputs.release_version }}"
+          scripts/build-llms-bundle.sh _site-workbench workbench "${{ steps.get-version.outputs.release_version }}"
 
       - name: Upload slim LLM bundles to S3
         env:
@@ -214,6 +214,8 @@ jobs:
           # Bucket-relative key prefix, not an s3:// URL: head-object takes
           # --bucket and --key separately.
           KEY_PREFIX="positron/${CHANNEL}/docs"
+          # Must match the value the upload step sets, character for character.
+          IMMUTABLE_CC="public, max-age=31536000, immutable"
 
           # head-object rather than `aws s3 ls`: `ls` on an exact key is a prefix
           # listing, and whether an empty listing exits non-zero depends on the
@@ -228,14 +230,19 @@ jobs:
             fi
           }
 
-          check_no_cache() {
+          # Assert both kinds, not just the aliases: `immutable` on a versioned
+          # object is the value that cannot be corrected later without an
+          # invalidation, so it is the more expensive one to get wrong.
+          check_cache_control() {
             local key="$1"
+            local expected="$2"
             local cc
             cc="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$key" \
                     --query 'CacheControl' --output text)"
-            if [ "$cc" != "no-cache" ]; then
-              echo "error: $key has Cache-Control '$cc', expected 'no-cache'." >&2
-              echo "A cached alias makes every conditional GET answer 304 forever." >&2
+            if [ "$cc" != "$expected" ]; then
+              echo "error: $key has Cache-Control '$cc', expected '$expected'." >&2
+              echo "A cached alias makes every conditional GET answer 304 forever;" >&2
+              echo "a non-immutable versioned object wastes a revalidation on every read." >&2
               exit 1
             fi
           }
@@ -247,6 +254,8 @@ jobs:
             # bundle that no install will ever use.
             assert_exists "${KEY_PREFIX}/${ZIP}"
             assert_exists "${KEY_PREFIX}/${ZIP}.sha256sum"
+            check_cache_control "${KEY_PREFIX}/${ZIP}" "$IMMUTABLE_CC"
+            check_cache_control "${KEY_PREFIX}/${ZIP}.sha256sum" "$IMMUTABLE_CC"
           done
 
           if [ "$CHANNEL" = "releases" ]; then
@@ -254,8 +263,8 @@ jobs:
               ALIAS="${BASENAME}-latest.zip"
               assert_exists "${KEY_PREFIX}/${ALIAS}"
               assert_exists "${KEY_PREFIX}/${ALIAS}.sha256sum"
-              check_no_cache "${KEY_PREFIX}/${ALIAS}"
-              check_no_cache "${KEY_PREFIX}/${ALIAS}.sha256sum"
+              check_cache_control "${KEY_PREFIX}/${ALIAS}" "no-cache"
+              check_cache_control "${KEY_PREFIX}/${ALIAS}.sha256sum" "no-cache"
             done
           fi
 

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -108,6 +108,11 @@ jobs:
           cd ../_site-workbench
           zip -r ../positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip .
 
+      - name: Create slim LLM docs bundles
+        run: |
+          scripts/build-llms-bundle.sh _site positron "${{ steps.get-version.outputs.release_version }}"
+          scripts/build-llms-bundle.sh _site-workbench workbench "${{ steps.get-version.outputs.release_version }}"
+
       - name: Delete existing release
         if: ${{ inputs.overwrite }}
         env:
@@ -148,6 +153,96 @@ jobs:
           S3_PREFIX="s3://posit-positron-downloads/positron/${{ inputs.release_channel }}/docs"
           aws s3 cp "positron-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
           aws s3 cp "positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
+
+      - name: Upload slim LLM bundles to S3
+        env:
+          VERSION: ${{ steps.get-version.outputs.release_version }}
+          CHANNEL: ${{ inputs.release_channel }}
+        run: |
+          set -euo pipefail
+          S3_PREFIX="s3://posit-positron-downloads/positron/${CHANNEL}/docs"
+
+          for BASENAME in positron-llms positron-workbench-llms; do
+            ZIP="${BASENAME}-${VERSION}.zip"
+
+            # Sidecar before zip: a zip reachable without its digest is a window
+            # in which a cold-cache Positron install gets no local docs.
+            aws s3 cp "${ZIP}.sha256sum" "${S3_PREFIX}/${ZIP}.sha256sum" \
+              --no-progress --cache-control "public, max-age=31536000, immutable"
+            aws s3 cp "${ZIP}" "${S3_PREFIX}/${ZIP}" \
+              --no-progress --cache-control "public, max-age=31536000, immutable"
+          done
+
+      - name: Move latest aliases
+        # Only the releases channel owns the mutable alias every install reads.
+        # A staging or dailies run must not repoint it.
+        if: ${{ inputs.release_channel == 'releases' }}
+        env:
+          VERSION: ${{ steps.get-version.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          S3_PREFIX="s3://posit-positron-downloads/positron/releases/docs"
+
+          for BASENAME in positron-llms positron-workbench-llms; do
+            ZIP="${BASENAME}-${VERSION}.zip"
+            ALIAS="${BASENAME}-latest.zip"
+
+            # Rewrite the sidecar to name the alias, so `shasum -c` against the
+            # downloaded alias still matches. Positron only reads the hex digest,
+            # but a self-consistent sidecar keeps manual verification honest.
+            DIGEST="$(cut -d' ' -f1 < "${ZIP}.sha256sum")"
+            printf '%s  %s\n' "$DIGEST" "$ALIAS" > "${ALIAS}.sha256sum"
+
+            # no-cache is what makes Positron's conditional GET meaningful:
+            # CloudFront revalidates with the origin, so a 304 genuinely means
+            # unchanged rather than "stale edge copy".
+            aws s3 cp "${ALIAS}.sha256sum" "${S3_PREFIX}/${ALIAS}.sha256sum" \
+              --no-progress --cache-control "no-cache"
+
+            # Source is the versioned zip: there is no local file named ${ALIAS}.
+            aws s3 cp "${ZIP}" "${S3_PREFIX}/${ALIAS}" \
+              --no-progress --cache-control "no-cache"
+          done
+
+      - name: Assert published LLM bundle objects
+        env:
+          VERSION: ${{ steps.get-version.outputs.release_version }}
+          CHANNEL: ${{ inputs.release_channel }}
+        run: |
+          set -euo pipefail
+          S3_PREFIX="s3://posit-positron-downloads/positron/${CHANNEL}/docs"
+          S3_BUCKET="posit-positron-downloads"
+
+          check_no_cache() {
+            local key="$1"
+            local cc
+            cc="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$key" \
+                    --query 'CacheControl' --output text)"
+            if [ "$cc" != "no-cache" ]; then
+              echo "error: $key has Cache-Control '$cc', expected 'no-cache'." >&2
+              echo "A cached alias makes every conditional GET answer 304 forever." >&2
+              exit 1
+            fi
+          }
+
+          for BASENAME in positron-llms positron-workbench-llms; do
+            ZIP="${BASENAME}-${VERSION}.zip"
+            # Every uploaded zip must have a reachable sidecar. Positron refuses
+            # to extract a zip it cannot verify, so a dropped sidecar ships a
+            # bundle that no install will ever use.
+            aws s3 ls "${S3_PREFIX}/${ZIP}" > /dev/null
+            aws s3 ls "${S3_PREFIX}/${ZIP}.sha256sum" > /dev/null
+          done
+
+          if [ "$CHANNEL" = "releases" ]; then
+            for BASENAME in positron-llms positron-workbench-llms; do
+              ALIAS="${BASENAME}-latest.zip"
+              aws s3 ls "${S3_PREFIX}/${ALIAS}" > /dev/null
+              aws s3 ls "${S3_PREFIX}/${ALIAS}.sha256sum" > /dev/null
+              check_no_cache "positron/${CHANNEL}/docs/${ALIAS}"
+              check_no_cache "positron/${CHANNEL}/docs/${ALIAS}.sha256sum"
+            done
+          fi
 
       - name: Configure AWS Credentials for CloudFront
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -210,8 +210,23 @@ jobs:
           CHANNEL: ${{ inputs.release_channel }}
         run: |
           set -euo pipefail
-          S3_PREFIX="s3://posit-positron-downloads/positron/${CHANNEL}/docs"
           S3_BUCKET="posit-positron-downloads"
+          # Bucket-relative key prefix, not an s3:// URL: head-object takes
+          # --bucket and --key separately.
+          KEY_PREFIX="positron/${CHANNEL}/docs"
+
+          # head-object rather than `aws s3 ls`: `ls` on an exact key is a prefix
+          # listing, and whether an empty listing exits non-zero depends on the
+          # AWS CLI major version (v2 exits 1, v1 exited 0). head-object fails on
+          # a missing key regardless, so the assertion does not silently weaken if
+          # the runner image's CLI ever changes.
+          assert_exists() {
+            local key="$1"
+            if ! aws s3api head-object --bucket "$S3_BUCKET" --key "$key" > /dev/null; then
+              echo "error: expected object $key is not present." >&2
+              exit 1
+            fi
+          }
 
           check_no_cache() {
             local key="$1"
@@ -230,17 +245,17 @@ jobs:
             # Every uploaded zip must have a reachable sidecar. Positron refuses
             # to extract a zip it cannot verify, so a dropped sidecar ships a
             # bundle that no install will ever use.
-            aws s3 ls "${S3_PREFIX}/${ZIP}" > /dev/null
-            aws s3 ls "${S3_PREFIX}/${ZIP}.sha256sum" > /dev/null
+            assert_exists "${KEY_PREFIX}/${ZIP}"
+            assert_exists "${KEY_PREFIX}/${ZIP}.sha256sum"
           done
 
           if [ "$CHANNEL" = "releases" ]; then
             for BASENAME in positron-llms positron-workbench-llms; do
               ALIAS="${BASENAME}-latest.zip"
-              aws s3 ls "${S3_PREFIX}/${ALIAS}" > /dev/null
-              aws s3 ls "${S3_PREFIX}/${ALIAS}.sha256sum" > /dev/null
-              check_no_cache "positron/${CHANNEL}/docs/${ALIAS}"
-              check_no_cache "positron/${CHANNEL}/docs/${ALIAS}.sha256sum"
+              assert_exists "${KEY_PREFIX}/${ALIAS}"
+              assert_exists "${KEY_PREFIX}/${ALIAS}.sha256sum"
+              check_no_cache "${KEY_PREFIX}/${ALIAS}"
+              check_no_cache "${KEY_PREFIX}/${ALIAS}.sha256sum"
             done
           fi
 

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -101,6 +101,65 @@ jobs:
           QUARTO_PROFILE: workbench
           RELEASE_VERSION: ${{ steps.get-version.outputs.release_version }}
 
+      - name: Create slim LLM docs bundles
+        # Built before anything is published. Every guard in this script is
+        # release-blocking, and running it after the GitHub release is cut and the
+        # full docs bundles are in S3 would turn a guard trip into a tagged,
+        # half-published release with no CloudFront invalidation.
+        run: |
+          scripts/build-llms-bundle.sh _site positron "${{ steps.get-version.outputs.release_version }}"
+          scripts/build-llms-bundle.sh _site-workbench workbench "${{ steps.get-version.outputs.release_version }}"
+
+      # Credentials are configured here rather than just before the first upload so
+      # the pre-flight check below can reach S3. Everything between here and the
+      # uploads only uses GH_TOKEN, so holding the S3 role across those steps is
+      # inert; the CloudFront step re-configures with its own role later.
+      - name: Configure AWS Credentials for S3
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_RW_ROLE }}
+          aws-region: us-east-1
+
+      - name: Pre-flight - refuse to silently replace published bundles
+        env:
+          VERSION: ${{ steps.get-version.outputs.release_version }}
+          CHANNEL: ${{ inputs.release_channel }}
+          OVERWRITE: ${{ inputs.overwrite }}
+        run: |
+          set -euo pipefail
+          S3_BUCKET="posit-positron-downloads"
+          KEY_PREFIX="positron/${CHANNEL}/docs"
+
+          # Versioned objects ship as `immutable, max-age=1y`, so any client that
+          # already fetched one will not revalidate it for a year. Republishing a
+          # version with different bytes strands those installs on the old bundle,
+          # and a CloudFront invalidation only purges edges, not clients.
+          #
+          # Keyed on `overwrite` rather than on a content comparison: the zip is
+          # not byte-reproducible (bundle.json carries a build timestamp), so
+          # "same content" is indistinguishable from "different content" and a
+          # digest check would reject every legitimate re-run. `overwrite` is
+          # already what the release runbook tells operators to set when
+          # re-publishing a docs release after edits.
+          #
+          # This runs before the release is cut and before any upload, so
+          # forgetting the flag costs a fast failure rather than a partially
+          # republished release.
+          if [ "$OVERWRITE" = "true" ]; then
+            echo "overwrite requested; existing objects under ${KEY_PREFIX} may be replaced."
+            exit 0
+          fi
+
+          for BASENAME in positron-llms positron-workbench-llms; do
+            KEY="${KEY_PREFIX}/${BASENAME}-${VERSION}.zip"
+            if aws s3api head-object --bucket "$S3_BUCKET" --key "$KEY" > /dev/null 2>&1; then
+              echo "error: $KEY is already published." >&2
+              echo "Versioned bundles are immutable. Bump the version, or re-run with 'overwrite'." >&2
+              exit 1
+            fi
+          done
+          echo "no published bundles for ${VERSION} on ${CHANNEL}; safe to proceed."
+
       - name: Create docs bundles
         run: |
           cd _site
@@ -137,22 +196,11 @@ jobs:
             positron-docs-${{ steps.get-version.outputs.release_version }}.zip \
             positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip
 
-      - name: Configure AWS Credentials for S3
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_S3_RW_ROLE }}
-          aws-region: us-east-1
-
       - name: Upload docs bundles to S3
         run: |
           S3_PREFIX="s3://posit-positron-downloads/positron/${{ inputs.release_channel }}/docs"
           aws s3 cp "positron-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
           aws s3 cp "positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" "${S3_PREFIX}/positron-workbench-docs-${{ steps.get-version.outputs.release_version }}.zip" --no-progress
-
-      - name: Create slim LLM docs bundles
-        run: |
-          scripts/build-llms-bundle.sh _site positron "${{ steps.get-version.outputs.release_version }}"
-          scripts/build-llms-bundle.sh _site-workbench workbench "${{ steps.get-version.outputs.release_version }}"
 
       - name: Upload slim LLM bundles to S3
         env:
@@ -160,6 +208,8 @@ jobs:
           CHANNEL: ${{ inputs.release_channel }}
         run: |
           set -euo pipefail
+          # Replacing an already-published version is gated by the pre-flight step
+          # above, so this step just uploads.
           S3_PREFIX="s3://posit-positron-downloads/positron/${CHANNEL}/docs"
 
           for BASENAME in positron-llms positron-workbench-llms; do
@@ -261,10 +311,36 @@ jobs:
           if [ "$CHANNEL" = "releases" ]; then
             for BASENAME in positron-llms positron-workbench-llms; do
               ALIAS="${BASENAME}-latest.zip"
+              ZIP="${BASENAME}-${VERSION}.zip"
               assert_exists "${KEY_PREFIX}/${ALIAS}"
               assert_exists "${KEY_PREFIX}/${ALIAS}.sha256sum"
               check_cache_control "${KEY_PREFIX}/${ALIAS}" "no-cache"
               check_cache_control "${KEY_PREFIX}/${ALIAS}.sha256sum" "no-cache"
+
+              # The alias move updates two bundles in a loop and is not atomic, so
+              # a mid-loop failure can leave positron-llms-latest.zip on this
+              # release and the workbench alias on the previous one. Verify the
+              # published bytes rather than trusting the copy succeeded: fetch the
+              # alias back and compare against this run's versioned sidecar.
+              EXPECTED="$(cut -d' ' -f1 < "${ZIP}.sha256sum")"
+
+              aws s3 cp "s3://${S3_BUCKET}/${KEY_PREFIX}/${ALIAS}" "verify-${ALIAS}" --no-progress
+              PUBLISHED="$(shasum -a 256 "verify-${ALIAS}" | cut -d' ' -f1)"
+              if [ "$PUBLISHED" != "$EXPECTED" ]; then
+                echo "error: ${ALIAS} does not hold this release's bundle." >&2
+                echo "It has $PUBLISHED, expected $EXPECTED (from ${ZIP})." >&2
+                exit 1
+              fi
+
+              # The sidecar the consumer verifies against must name that same
+              # digest, or every install rejects the bundle it just downloaded.
+              aws s3 cp "s3://${S3_BUCKET}/${KEY_PREFIX}/${ALIAS}.sha256sum" \
+                "verify-${ALIAS}.sha256sum" --no-progress
+              SIDECAR="$(cut -d' ' -f1 < "verify-${ALIAS}.sha256sum")"
+              if [ "$SIDECAR" != "$EXPECTED" ]; then
+                echo "error: ${ALIAS}.sha256sum names $SIDECAR but the alias holds $EXPECTED." >&2
+                exit 1
+              fi
             done
           fi
 

--- a/.github/workflows/release-docs-bundles.yml
+++ b/.github/workflows/release-docs-bundles.yml
@@ -219,7 +219,7 @@ jobs:
           for BASENAME in positron-llms positron-workbench-llms; do
             ZIP="${BASENAME}-${VERSION}.zip"
 
-            # Sidecar before zip: a zip reachable without its digest is a window
+            # Checksum before zip: a zip reachable without its digest is a window
             # in which a cold-cache Positron install gets no local docs.
             aws s3 cp "${ZIP}.sha256sum" "${S3_PREFIX}/${ZIP}.sha256sum" \
               --no-progress --cache-control "public, max-age=31536000, immutable"
@@ -241,9 +241,9 @@ jobs:
             ZIP="${BASENAME}-${VERSION}.zip"
             ALIAS="${BASENAME}-latest.zip"
 
-            # Rewrite the sidecar to name the alias, so `shasum -c` against the
+            # Rewrite the checksum file to name the alias, so `shasum -c` against the
             # downloaded alias still matches. Positron only reads the hex digest,
-            # but a self-consistent sidecar keeps manual verification honest.
+            # but a self-consistent checksum file keeps manual verification honest.
             DIGEST="$(cut -d' ' -f1 < "${ZIP}.sha256sum")"
             printf '%s  %s\n' "$DIGEST" "$ALIAS" > "${ALIAS}.sha256sum"
 
@@ -303,8 +303,8 @@ jobs:
 
           for BASENAME in positron-llms positron-workbench-llms; do
             ZIP="${BASENAME}-${VERSION}.zip"
-            # Every uploaded zip must have a reachable sidecar. Positron refuses
-            # to extract a zip it cannot verify, so a dropped sidecar ships a
+            # Every uploaded zip must have a reachable checksum file. Positron refuses
+            # to extract a zip it cannot verify, so a dropped checksum file ships a
             # bundle that no install will ever use.
             assert_exists "${KEY_PREFIX}/${ZIP}"
             assert_exists "${KEY_PREFIX}/${ZIP}.sha256sum"
@@ -325,7 +325,7 @@ jobs:
               # a mid-loop failure can leave positron-llms-latest.zip on this
               # release and the workbench alias on the previous one. Verify the
               # published bytes rather than trusting the copy succeeded: fetch the
-              # alias back and compare against this run's versioned sidecar.
+              # alias back and compare against this run's versioned checksum file.
               EXPECTED="$(cut -d' ' -f1 < "${ZIP}.sha256sum")"
 
               aws s3 cp "s3://${S3_BUCKET}/${KEY_PREFIX}/${ALIAS}" "verify-${ALIAS}" --no-progress
@@ -336,13 +336,13 @@ jobs:
                 exit 1
               fi
 
-              # The sidecar the consumer verifies against must name that same
+              # The checksum file the consumer verifies against must name that same
               # digest, or every install rejects the bundle it just downloaded.
               aws s3 cp "s3://${S3_BUCKET}/${KEY_PREFIX}/${ALIAS}.sha256sum" \
                 "verify-${ALIAS}.sha256sum" --no-progress
-              SIDECAR="$(cut -d' ' -f1 < "verify-${ALIAS}.sha256sum")"
-              if [ "$SIDECAR" != "$EXPECTED" ]; then
-                echo "error: ${ALIAS}.sha256sum names $SIDECAR but the alias holds $EXPECTED." >&2
+              PUBLISHED_DIGEST="$(cut -d' ' -f1 < "verify-${ALIAS}.sha256sum")"
+              if [ "$PUBLISHED_DIGEST" != "$EXPECTED" ]; then
+                echo "error: ${ALIAS}.sha256sum names $PUBLISHED_DIGEST but the alias holds $EXPECTED." >&2
                 exit 1
               fi
             done

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -46,7 +46,10 @@ cp "$SITE_DIR/llms.txt" "$STAGE/llms.txt"
 # and exits non-zero while BSD tar exits 0, so without this the same broken
 # render fails cryptically on CI and silently on a Mac. A bundle of llms.txt
 # plus bundle.json and no docs is useless either way.
-DOC_COUNT="$(cd "$SITE_DIR" && find . -name '*.llms.md' -type f | wc -l | tr -d ' ')"
+# Counting NUL bytes from -print0 rather than lines from `wc -l`: a filename
+# containing a newline would otherwise inflate the count and trip the staged-count
+# comparison at step 5 with a mismatch that points at the wrong cause.
+DOC_COUNT="$(cd "$SITE_DIR" && find . -name '*.llms.md' -type f -print0 | tr -dc '\0' | wc -c | tr -d ' ')"
 if [ "$DOC_COUNT" -eq 0 ]; then
 	echo "error: no *.llms.md files under $SITE_DIR; the Quarto render produced no LLM docs." >&2
 	exit 1
@@ -58,21 +61,28 @@ fi
 # 2. Rewrite llms.txt to bundle-relative paths. This is what schema 1 promises.
 # Write-and-move rather than `sed -i`: in-place editing needs no suffix on GNU
 # sed and a mandatory one on BSD, so no single `-i` spelling is portable.
-sed "s|https://positron\\.posit\\.co/||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
+# `-E` with an optional trailing slash so the bare origin is stripped too:
+# site-url carries no trailing slash, so both forms appear in practice.
+sed -E "s|https://positron\\.posit\\.co/?||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
 mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 
-# 3. Guard: no bundled file may still reference the site. Paths are reported
-# relative to $SITE_DIR, since a mktemp path is not actionable for an operator.
-if grep -rl 'positron\.posit\.co' "$STAGE" | sed "s|^$STAGE/|$SITE_DIR/|" | grep . ; then
-	echo "error: bundled files still reference positron.posit.co (listed above)." >&2
-	echo "The rewrite assumes only llms.txt carries site links. That assumption broke." >&2
+# 3. Guard: llms.txt must no longer reference the site. Scoped to llms.txt
+# because that is the only file step 2 rewrites. The .llms.md docs legitimately
+# carry absolute site links in prose -- release notes link to doc pages -- and
+# those stay valid URLs for a reader who has a browser, so failing on them would
+# turn ordinary docs authoring into a broken release.
+if grep -n 'positron\.posit\.co' "$STAGE/llms.txt" ; then
+	echo "error: llms.txt still references positron.posit.co (listed above)." >&2
+	echo "The rewrite in step 2 did not cover every form of the site URL." >&2
 	exit 1
 fi
 
-# 4. Guard: every link in llms.txt must now be bundle-relative. Matches any
-# scheme case-insensitively, scheme-relative `//host`, and root-relative `/path`
-# - none of which resolve inside an extracted bundle.
-if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -Ei '\(([a-z][a-z0-9+.-]*:)?//|\(/' ; then
+# 4. Guard: every link in llms.txt must now be bundle-relative. Rejects any
+# scheme case-insensitively (`https:`, and also non-slash ones like `mailto:`,
+# which would otherwise reach step 5 and be reported as a missing file),
+# scheme-relative `//host`, and root-relative `/path` - none of which resolve
+# inside an extracted bundle.
+if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -Ei '\((([a-z][a-z0-9+.-]*:)|//|/)' ; then
 	echo "error: llms.txt contains links that are not bundle-relative (listed above)." >&2
 	exit 1
 fi
@@ -85,7 +95,10 @@ fi
 # self-consistent whatever is missing.
 MISSING_LINKS=0
 while IFS= read -r target; do
+	# Fragment first, then query: a link is path?query#fragment, and neither
+	# suffix is part of the filename on disk.
 	target="${target%%#*}"
+	target="${target%%\?*}"
 	[ -n "$target" ] || continue
 	if [ ! -f "$STAGE/$target" ]; then
 		echo "error: llms.txt links '$target', which is not in the bundle." >&2
@@ -98,7 +111,7 @@ if [ "$MISSING_LINKS" -ne 0 ]; then
 	exit 1
 fi
 
-FILE_COUNT="$(find "$STAGE" -type f | wc -l | tr -d ' ')"
+FILE_COUNT="$(find "$STAGE" -type f -print0 | tr -dc '\0' | wc -c | tr -d ' ')"
 
 # llms.txt plus the docs counted at step 1. A mismatch means the tar pipe
 # dropped or duplicated something between the site dir and the stage.

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -61,22 +61,53 @@ fi
 sed "s|${DOCS_BASE_URL}||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
 mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 
-# 3. Guard: no bundled file may still reference the site.
-if grep -rl 'positron\.posit\.co' "$STAGE" ; then
+# 3. Guard: no bundled file may still reference the site. Paths are reported
+# relative to $SITE_DIR, since a mktemp path is not actionable for an operator.
+if grep -rl 'positron\.posit\.co' "$STAGE" | sed "s|^$STAGE/|$SITE_DIR/|" | grep . ; then
 	echo "error: bundled files still reference positron.posit.co (listed above)." >&2
 	echo "The rewrite assumes only llms.txt carries site links. That assumption broke." >&2
 	exit 1
 fi
 
-# 4. Guard: every link in llms.txt must now be bundle-relative.
-if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -E '\((https?:)?//' ; then
-	echo "error: llms.txt still contains absolute links (listed above)." >&2
+# 4. Guard: every link in llms.txt must now be bundle-relative. Matches any
+# scheme case-insensitively, scheme-relative `//host`, and root-relative `/path`
+# - none of which resolve inside an extracted bundle.
+if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -Ei '\(([a-z][a-z0-9+.-]*:)?//|\(/' ; then
+	echo "error: llms.txt contains links that are not bundle-relative (listed above)." >&2
+	exit 1
+fi
+
+# 5. Guard: every link target must exist in the bundle. llms.txt is the
+# consumer's only index, and Quarto builds it from the page list rather than from
+# what it actually wrote, so a partial render yields an index pointing at files
+# that are not there. Nothing else in this script can catch that: the file count
+# is measured from $STAGE and compared against a zip built from $STAGE, so it is
+# self-consistent whatever is missing.
+MISSING_LINKS=0
+while IFS= read -r target; do
+	target="${target%%#*}"
+	[ -n "$target" ] || continue
+	if [ ! -f "$STAGE/$target" ]; then
+		echo "error: llms.txt links '$target', which is not in the bundle." >&2
+		MISSING_LINKS=$((MISSING_LINKS + 1))
+	fi
+done < <(grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | sed 's/^](//; s/)$//')
+if [ "$MISSING_LINKS" -ne 0 ]; then
+	echo "error: $MISSING_LINKS llms.txt link(s) do not resolve inside the bundle." >&2
+	echo "The Quarto render is probably incomplete." >&2
 	exit 1
 fi
 
 FILE_COUNT="$(find "$STAGE" -type f | wc -l | tr -d ' ')"
 
-# 5. Generate bundle.json, then include it in the count it reports.
+# llms.txt plus the docs counted at step 1. A mismatch means the tar pipe
+# dropped or duplicated something between the site dir and the stage.
+if [ "$FILE_COUNT" -ne "$((DOC_COUNT + 1))" ]; then
+	echo "error: staged $FILE_COUNT files, expected $((DOC_COUNT + 1))." >&2
+	exit 1
+fi
+
+# 6. Generate bundle.json, then include it in the count it reports.
 cat > "$STAGE/bundle.json" <<JSON
 {
   "schema": ${SCHEMA},
@@ -88,7 +119,7 @@ cat > "$STAGE/bundle.json" <<JSON
 }
 JSON
 
-# 6. Zip, then verify the archive round-trips the guards.
+# 7. Zip, then verify its entry list and count match what was staged.
 rm -f "$ZIP_NAME"
 ( cd "$STAGE" && zip -q -r -X "$OUT_DIR/$ZIP_NAME" . )
 
@@ -110,7 +141,7 @@ if [ "$ZIPPED_COUNT" -ne "$DECLARED_COUNT" ]; then
 	exit 1
 fi
 
-# 7. Digest sidecar. Positron refuses to extract without a matching one.
+# 8. Digest sidecar. Positron refuses to extract without a matching one.
 shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256sum"
 shasum -a 256 -c "${ZIP_NAME}.sha256sum"
 

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -19,6 +19,21 @@ VERSION="${3:?usage: build-llms-bundle.sh <site-dir> <profile> <version>}"
 SCHEMA=1
 DOCS_BASE_URL="https://positron.posit.co/"
 
+# Escape ERE metacharacters so DOCS_BASE_URL can be spliced into the patterns at
+# steps 2 and 3. `|` is in the set because step 2 uses it as the sed delimiter.
+escape_ere() {
+	printf '%s' "$1" | sed 's/[][^$.*+?(){}|\\]/\\&/g'
+}
+
+# Derived from DOCS_BASE_URL rather than spelled out again: changing the domain
+# must not leave step 2 stripping one host while step 3 hunts for another.
+# Step 3 matches the bare host, not the full origin, so it still catches the
+# `http://` and `//host` forms that step 2's scheme-qualified rewrite leaves be.
+DOCS_BASE_ORIGIN="${DOCS_BASE_URL%/}"
+DOCS_BASE_HOST="${DOCS_BASE_ORIGIN#*://}"
+DOCS_BASE_ORIGIN_RE="$(escape_ere "$DOCS_BASE_ORIGIN")"
+DOCS_BASE_HOST_RE="$(escape_ere "$DOCS_BASE_HOST")"
+
 case "$PROFILE" in
 	positron)  BASENAME="positron-llms" ;;
 	workbench) BASENAME="positron-workbench-llms" ;;
@@ -63,7 +78,7 @@ fi
 # sed and a mandatory one on BSD, so no single `-i` spelling is portable.
 # `-E` with an optional trailing slash so the bare origin is stripped too:
 # site-url carries no trailing slash, so both forms appear in practice.
-sed -E "s|https://positron\\.posit\\.co/?||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
+sed -E "s|${DOCS_BASE_ORIGIN_RE}/?||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
 mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 
 # 3. Guard: llms.txt must no longer reference the site. Scoped to llms.txt
@@ -71,8 +86,8 @@ mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 # carry absolute site links in prose -- release notes link to doc pages -- and
 # those stay valid URLs for a reader who has a browser, so failing on them would
 # turn ordinary docs authoring into a broken release.
-if grep -n 'positron\.posit\.co' "$STAGE/llms.txt" ; then
-	echo "error: llms.txt still references positron.posit.co (listed above)." >&2
+if grep -nE "$DOCS_BASE_HOST_RE" "$STAGE/llms.txt" ; then
+	echo "error: llms.txt still references $DOCS_BASE_HOST (listed above)." >&2
 	echo "The rewrite in step 2 did not cover every form of the site URL." >&2
 	exit 1
 fi

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -26,7 +26,7 @@ case "$PROFILE" in
 esac
 
 ZIP_NAME="${BASENAME}-${VERSION}.zip"
-# Captured before any `cd`: the zip is written here, and step 6 zips from inside
+# Captured before any `cd`: the zip is written here, and step 7 zips from inside
 # $STAGE, so a relative path or $OLDPWD would resolve against the wrong dir.
 OUT_DIR="$PWD"
 STAGE="$(mktemp -d)"

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -47,12 +47,18 @@ OUT_DIR="$PWD"
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 
+# Step 0 -- Precondition
+# Scope:  $SITE_DIR
+# Action: Fail if the Quarto render produced no llms.txt
 if [ ! -f "$SITE_DIR/llms.txt" ]; then
 	echo "error: $SITE_DIR/llms.txt not found; did the Quarto render run?" >&2
 	exit 1
 fi
 
-# 1. Copy llms.txt and every *.llms.md, preserving directory structure.
+# Step 1 -- Stage
+# Scope:  llms.txt + every *.llms.md
+# Action: Copy the bundle contents, preserving directory structure
+#
 # A tar pipe rather than `cp --parents`: that flag is GNU-only, and this script
 # must run on a contributor's macOS checkout as well as the Linux runner.
 cp "$SITE_DIR/llms.txt" "$STAGE/llms.txt"
@@ -73,7 +79,11 @@ fi
 ( cd "$SITE_DIR" && find . -name '*.llms.md' -type f -print0 | tar -cf - --null -T - ) \
 	| ( cd "$STAGE" && tar -xf - )
 
-# 2. Rewrite llms.txt to bundle-relative paths. This is what schema 1 promises.
+# Step 2 -- Rewrite
+# Scope:  llms.txt
+# Action: Turn absolute site URLs into bundle-relative paths
+#
+# This is what schema 1 promises.
 # Write-and-move rather than `sed -i`: in-place editing needs no suffix on GNU
 # sed and a mandatory one on BSD, so no single `-i` spelling is portable.
 # `-E` with an optional trailing slash so the bare origin is stripped too:
@@ -81,8 +91,12 @@ fi
 sed -E "s|${DOCS_BASE_ORIGIN_RE}/?||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
 mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 
-# 3. Guard: llms.txt must no longer reference the site. Scoped to llms.txt
-# because that is the only file step 2 rewrites. The .llms.md docs legitimately
+# Step 3 -- Guard
+# Scope:  llms.txt
+# Action: Fail if any site URL survived step 2
+#
+# Scoped to llms.txt because that is the only file step 2 rewrites. The .llms.md
+# docs legitimately
 # carry absolute site links in prose -- release notes link to doc pages -- and
 # those stay valid URLs for a reader who has a browser, so failing on them would
 # turn ordinary docs authoring into a broken release.
@@ -92,8 +106,11 @@ if grep -nE "$DOCS_BASE_HOST_RE" "$STAGE/llms.txt" ; then
 	exit 1
 fi
 
-# 4. Guard: every link in llms.txt must now be bundle-relative. Rejects any
-# scheme case-insensitively (`https:`, and also non-slash ones like `mailto:`,
+# Step 4 -- Guard
+# Scope:  llms.txt
+# Action: Fail if any link is not a plain relative path
+#
+# Rejects any scheme case-insensitively (`https:`, and also non-slash ones like `mailto:`,
 # which would otherwise reach step 5 and be reported as a missing file),
 # scheme-relative `//host`, and root-relative `/path` - none of which resolve
 # inside an extracted bundle.
@@ -102,8 +119,11 @@ if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -Ei '\((([a-z][a-z0-9+.-]*:)|
 	exit 1
 fi
 
-# 5. Guard: every link target must exist in the bundle. llms.txt is the
-# consumer's only index, and Quarto builds it from the page list rather than from
+# Step 5 -- Guard
+# Scope:  llms.txt links, staged files
+# Action: Fail if a link target is missing, or the staged file count is wrong
+#
+# llms.txt is the consumer's only index, and Quarto builds it from the page list rather than from
 # what it actually wrote, so a partial render yields an index pointing at files
 # that are not there. Nothing else in this script can catch that: the file count
 # is measured from $STAGE and compared against a zip built from $STAGE, so it is
@@ -135,7 +155,11 @@ if [ "$FILE_COUNT" -ne "$((DOC_COUNT + 1))" ]; then
 	exit 1
 fi
 
-# 6. Generate bundle.json, then include it in the count it reports.
+# Step 6 -- Manifest
+# Scope:  bundle.json
+# Action: Write schema, profile, version, timestamp, file count
+#
+# The count includes bundle.json itself.
 cat > "$STAGE/bundle.json" <<JSON
 {
   "schema": ${SCHEMA},
@@ -147,7 +171,9 @@ cat > "$STAGE/bundle.json" <<JSON
 }
 JSON
 
-# 7. Zip, then verify its entry list and count match what was staged.
+# Step 7 -- Package
+# Scope:  the zip
+# Action: Zip the stage, then fail if its entry list or count disagree
 rm -f "$ZIP_NAME"
 ( cd "$STAGE" && zip -q -r -X "$OUT_DIR/$ZIP_NAME" . )
 
@@ -169,7 +195,9 @@ if [ "$ZIPPED_COUNT" -ne "$DECLARED_COUNT" ]; then
 	exit 1
 fi
 
-# 8. Guard: the zip must stay inside the size budget.
+# Step 8 -- Guard
+# Scope:  the zip
+# Action: Fail if the zip is over the size budget
 #
 # Positron caps the download it will accept (DOCS_MAX_DOWNLOAD_BYTES, 25MB) and
 # a client that trips that cap silently falls back to web docs. Since the cap is
@@ -189,7 +217,11 @@ if [ "$ZIP_BYTES" -gt "$MAX_BYTES" ]; then
 	exit 1
 fi
 
-# 9. Checksum file. Positron refuses to extract without a matching one.
+# Step 9 -- Checksum
+# Scope:  the zip
+# Action: Write the .sha256sum and verify it
+#
+# Positron refuses to extract without a matching one.
 shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256sum"
 shasum -a 256 -c "${ZIP_NAME}.sha256sum"
 

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -58,7 +58,7 @@ fi
 # 2. Rewrite llms.txt to bundle-relative paths. This is what schema 1 promises.
 # Write-and-move rather than `sed -i`: in-place editing needs no suffix on GNU
 # sed and a mandatory one on BSD, so no single `-i` spelling is portable.
-sed "s|${DOCS_BASE_URL}||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
+sed "s|https://positron\\.posit\\.co/||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
 mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
 
 # 3. Guard: no bundled file may still reference the site. Paths are reported
@@ -129,8 +129,8 @@ rm -f "$ZIP_NAME"
 # (141) fails the pipeline even though the archive is fine.
 ENTRIES="$(unzip -Z1 "$ZIP_NAME")"
 
-grep -qx 'llms.txt' <<<"$ENTRIES"    || { echo "error: zip missing llms.txt" >&2; exit 1; }
-grep -qx 'bundle.json' <<<"$ENTRIES" || { echo "error: zip missing bundle.json" >&2; exit 1; }
+grep -q 'llms\.txt$' <<<"$ENTRIES"    || { echo "error: zip missing llms.txt" >&2; exit 1; }
+grep -q 'bundle\.json$' <<<"$ENTRIES" || { echo "error: zip missing bundle.json" >&2; exit 1; }
 
 # `grep -c` exits 1 on a zero count, which `set -e` would treat as fatal, so
 # tolerate it and let the comparison below report the real mismatch.

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -189,8 +189,8 @@ if [ "$ZIP_BYTES" -gt "$MAX_BYTES" ]; then
 	exit 1
 fi
 
-# 9. Digest sidecar. Positron refuses to extract without a matching one.
+# 9. Checksum file. Positron refuses to extract without a matching one.
 shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256sum"
 shasum -a 256 -c "${ZIP_NAME}.sha256sum"
 
-echo "built $ZIP_NAME ($(wc -c < "$ZIP_NAME") bytes, $DECLARED_COUNT files) + sidecar"
+echo "built $ZIP_NAME ($(wc -c < "$ZIP_NAME") bytes, $DECLARED_COUNT files) + checksum"

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -41,6 +41,17 @@ fi
 # A tar pipe rather than `cp --parents`: that flag is GNU-only, and this script
 # must run on a contributor's macOS checkout as well as the Linux runner.
 cp "$SITE_DIR/llms.txt" "$STAGE/llms.txt"
+
+# Guard the empty case before taring: GNU tar refuses to create an empty archive
+# and exits non-zero while BSD tar exits 0, so without this the same broken
+# render fails cryptically on CI and silently on a Mac. A bundle of llms.txt
+# plus bundle.json and no docs is useless either way.
+DOC_COUNT="$(cd "$SITE_DIR" && find . -name '*.llms.md' -type f | wc -l | tr -d ' ')"
+if [ "$DOC_COUNT" -eq 0 ]; then
+	echo "error: no *.llms.md files under $SITE_DIR; the Quarto render produced no LLM docs." >&2
+	exit 1
+fi
+
 ( cd "$SITE_DIR" && find . -name '*.llms.md' -type f -print0 | tar -cf - --null -T - ) \
 	| ( cd "$STAGE" && tar -xf - )
 

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Build the slim LLM-only docs bundle from a rendered Quarto site.
+#
+# Emits <basename>-<version>.zip and <basename>-<version>.zip.sha256sum in the
+# current directory, where <basename> is positron-llms or positron-workbench-llms.
+#
+# Every guard here is load-bearing: the bundle is consumed by Positron's
+# parseManifest(), which rejects anything it does not recognise, so a bad
+# bundle must fail this workflow rather than ship.
+set -euo pipefail
+
+SITE_DIR="${1:?usage: build-llms-bundle.sh <site-dir> <profile> <version>}"
+PROFILE="${2:?usage: build-llms-bundle.sh <site-dir> <profile> <version>}"
+VERSION="${3:?usage: build-llms-bundle.sh <site-dir> <profile> <version>}"
+
+# Bump only when a schema-1 reader would misread the bundle. See the design
+# spec's "Schema versioning policy" section before changing this.
+SCHEMA=1
+DOCS_BASE_URL="https://positron.posit.co/"
+
+case "$PROFILE" in
+	positron)  BASENAME="positron-llms" ;;
+	workbench) BASENAME="positron-workbench-llms" ;;
+	*) echo "error: profile must be 'positron' or 'workbench', got '$PROFILE'" >&2; exit 1 ;;
+esac
+
+ZIP_NAME="${BASENAME}-${VERSION}.zip"
+# Captured before any `cd`: the zip is written here, and step 6 zips from inside
+# $STAGE, so a relative path or $OLDPWD would resolve against the wrong dir.
+OUT_DIR="$PWD"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+if [ ! -f "$SITE_DIR/llms.txt" ]; then
+	echo "error: $SITE_DIR/llms.txt not found; did the Quarto render run?" >&2
+	exit 1
+fi
+
+# 1. Copy llms.txt and every *.llms.md, preserving directory structure.
+# A tar pipe rather than `cp --parents`: that flag is GNU-only, and this script
+# must run on a contributor's macOS checkout as well as the Linux runner.
+cp "$SITE_DIR/llms.txt" "$STAGE/llms.txt"
+( cd "$SITE_DIR" && find . -name '*.llms.md' -type f -print0 | tar -cf - --null -T - ) \
+	| ( cd "$STAGE" && tar -xf - )
+
+# 2. Rewrite llms.txt to bundle-relative paths. This is what schema 1 promises.
+# Write-and-move rather than `sed -i`: in-place editing needs no suffix on GNU
+# sed and a mandatory one on BSD, so no single `-i` spelling is portable.
+sed "s|${DOCS_BASE_URL}||g" "$STAGE/llms.txt" > "$STAGE/llms.txt.rewritten"
+mv "$STAGE/llms.txt.rewritten" "$STAGE/llms.txt"
+
+# 3. Guard: no bundled file may still reference the site.
+if grep -rl 'positron\.posit\.co' "$STAGE" ; then
+	echo "error: bundled files still reference positron.posit.co (listed above)." >&2
+	echo "The rewrite assumes only llms.txt carries site links. That assumption broke." >&2
+	exit 1
+fi
+
+# 4. Guard: every link in llms.txt must now be bundle-relative.
+if grep -oE '\]\([^)]+\)' "$STAGE/llms.txt" | grep -E '\((https?:)?//' ; then
+	echo "error: llms.txt still contains absolute links (listed above)." >&2
+	exit 1
+fi
+
+FILE_COUNT="$(find "$STAGE" -type f | wc -l | tr -d ' ')"
+
+# 5. Generate bundle.json, then include it in the count it reports.
+cat > "$STAGE/bundle.json" <<JSON
+{
+  "schema": ${SCHEMA},
+  "profile": "${PROFILE}",
+  "version": "${VERSION}",
+  "generated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "docsBaseUrl": "${DOCS_BASE_URL}",
+  "fileCount": $((FILE_COUNT + 1))
+}
+JSON
+
+# 6. Zip, then verify the archive round-trips the guards.
+rm -f "$ZIP_NAME"
+( cd "$STAGE" && zip -q -r -X "$OUT_DIR/$ZIP_NAME" . )
+
+# Read the entry list once into a variable rather than piping `unzip` into
+# `grep -q` per check. Under `set -o pipefail` a `grep -q` that matches early
+# can close the pipe before `unzip` finishes writing, and the resulting SIGPIPE
+# (141) fails the pipeline even though the archive is fine.
+ENTRIES="$(unzip -Z1 "$ZIP_NAME")"
+
+grep -qx 'llms.txt' <<<"$ENTRIES"    || { echo "error: zip missing llms.txt" >&2; exit 1; }
+grep -qx 'bundle.json' <<<"$ENTRIES" || { echo "error: zip missing bundle.json" >&2; exit 1; }
+
+# `grep -c` exits 1 on a zero count, which `set -e` would treat as fatal, so
+# tolerate it and let the comparison below report the real mismatch.
+ZIPPED_COUNT="$(grep -vc '/$' <<<"$ENTRIES" || true)"
+DECLARED_COUNT="$((FILE_COUNT + 1))"
+if [ "$ZIPPED_COUNT" -ne "$DECLARED_COUNT" ]; then
+	echo "error: zip holds $ZIPPED_COUNT files but bundle.json declares $DECLARED_COUNT" >&2
+	exit 1
+fi
+
+# 7. Digest sidecar. Positron refuses to extract without a matching one.
+shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256sum"
+shasum -a 256 -c "${ZIP_NAME}.sha256sum"
+
+echo "built $ZIP_NAME ($(wc -c < "$ZIP_NAME") bytes, $DECLARED_COUNT files) + sidecar"

--- a/scripts/build-llms-bundle.sh
+++ b/scripts/build-llms-bundle.sh
@@ -169,7 +169,27 @@ if [ "$ZIPPED_COUNT" -ne "$DECLARED_COUNT" ]; then
 	exit 1
 fi
 
-# 8. Digest sidecar. Positron refuses to extract without a matching one.
+# 8. Guard: the zip must stay inside the size budget.
+#
+# Positron caps the download it will accept (DOCS_MAX_DOWNLOAD_BYTES, 25MB) and
+# a client that trips that cap silently falls back to web docs. Since the cap is
+# baked into a shipped build while this bundle publishes on the website's own
+# cadence, an oversize bundle would break clients that can no longer be fixed.
+# So the real budget is enforced here, far below the client cap, where exceeding
+# it fails a build someone can react to.
+#
+# If this fires on legitimate growth, raise MAX_BYTES - and check it against
+# DOCS_MAX_DOWNLOAD_BYTES in Positron's positronDocsBundle.ts, since the oldest
+# supported client's cap is the one that actually binds.
+MAX_BYTES="${LLMS_BUNDLE_MAX_BYTES:-1048576}"   # 1MB; the real bundle is ~150KB
+ZIP_BYTES="$(wc -c < "$ZIP_NAME" | tr -d ' ')"
+if [ "$ZIP_BYTES" -gt "$MAX_BYTES" ]; then
+	echo "error: $ZIP_NAME is $ZIP_BYTES bytes, over the $MAX_BYTES byte budget." >&2
+	echo "See the size-budget note in this script before raising it." >&2
+	exit 1
+fi
+
+# 9. Digest sidecar. Positron refuses to extract without a matching one.
 shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256sum"
 shasum -a 256 -c "${ZIP_NAME}.sha256sum"
 

--- a/scripts/test-build-llms-bundle.sh
+++ b/scripts/test-build-llms-bundle.sh
@@ -183,6 +183,15 @@ expect_fail "site URL the rewrite missed" "still references positron.posit.co" \
 new_site
 expect_fail "unknown profile" "profile must be" _site dailies 0.0.0-test
 
+# The size budget, exercised by shrinking the budget rather than by padding a
+# fixture past 1MB. Exported and unset around the call: an assignment prefixing a
+# function call stays in effect afterwards in bash, which would silently cap
+# every later case.
+new_site
+export LLMS_BUNDLE_MAX_BYTES=100
+expect_fail "zip over the size budget" "over the 100 byte budget" _site positron 0.0.0-test
+unset LLMS_BUNDLE_MAX_BYTES
+
 echo
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-build-llms-bundle.sh
+++ b/scripts/test-build-llms-bundle.sh
@@ -122,9 +122,9 @@ else
 fi
 
 if shasum -a 256 -c positron-llms-0.0.0-test.zip.sha256sum > /dev/null 2>&1; then
-	report "sidecar digest verifies" yes
+	report "checksum file verifies" yes
 else
-	report "sidecar digest verifies" no ""
+	report "checksum file verifies" no ""
 fi
 
 new_site

--- a/scripts/test-build-llms-bundle.sh
+++ b/scripts/test-build-llms-bundle.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# Fixture-based tests for build-llms-bundle.sh.
+#
+# The bundle script otherwise only ever runs during a real release, against a
+# rendered site that needs Quarto >= 1.8 to produce llms output at all. These
+# tests stand in for that: each case builds a small fake rendered site, runs the
+# script, and asserts on the exit status and the operator-facing message.
+#
+# Run locally with: scripts/test-build-llms-bundle.sh
+#
+# Deliberately not `set -e`: most cases assert a non-zero exit.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE_SCRIPT="$SCRIPT_DIR/build-llms-bundle.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+
+PASS=0
+FAIL=0
+
+report() {
+	if [ "$2" = yes ]; then
+		printf 'ok   %s\n' "$1"
+		PASS=$((PASS + 1))
+	else
+		printf 'FAIL %s\n' "$1"
+		[ -n "${3:-}" ] && printf '     %s\n' "$3"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# A minimal rendered site. The llms.txt link form mirrors what Quarto emits for a
+# site with site-url set: absolute URLs pointing at the .llms.md variants.
+new_site() {
+	rm -rf _site
+	mkdir -p _site/guides
+	cat > _site/llms.txt <<'EOF'
+# Positron
+
+## Pages
+
+- [Databot](https://positron.posit.co/databot.llms.md)
+- [Setup](https://positron.posit.co/guides/setup.llms.md)
+EOF
+	printf '# Databot\n\nSee the [extension](https://open-vsx.org/extension/posit/databot).\n' \
+		> _site/databot.llms.md
+	printf '# Setup\n\nHello.\n' > _site/guides/setup.llms.md
+}
+
+# Captures combined output in $OUT and the exit status in $STATUS.
+run_bundle() {
+	OUT="$("$BUNDLE_SCRIPT" "$@" 2>&1)"
+	STATUS=$?
+}
+
+expect_ok() {
+	local name="$1"
+	shift
+	run_bundle "$@"
+	if [ "$STATUS" -eq 0 ]; then
+		report "$name" yes
+	else
+		report "$name" no "expected success, got exit $STATUS: $OUT"
+	fi
+}
+
+expect_fail() {
+	local name="$1" pattern="$2"
+	shift 2
+	run_bundle "$@"
+	if [ "$STATUS" -eq 0 ]; then
+		report "$name" no "expected failure, got exit 0"
+	elif ! grep -qF "$pattern" <<<"$OUT"; then
+		report "$name" no "exit $STATUS but message lacked '$pattern': $OUT"
+	else
+		report "$name" yes
+	fi
+}
+
+echo "== accepted =="
+
+new_site
+expect_ok "positron profile builds" _site positron 0.0.0-test
+
+# Artifact shape, checked once on the happy path.
+ENTRIES="$(unzip -Z1 positron-llms-0.0.0-test.zip)"
+for want in llms.txt bundle.json databot.llms.md guides/setup.llms.md; do
+	if grep -qxF "$want" <<<"$ENTRIES"; then
+		report "zip contains $want" yes
+	else
+		report "zip contains $want" no "entries: $(tr '\n' ' ' <<<"$ENTRIES")"
+	fi
+done
+
+MANIFEST="$(unzip -p positron-llms-0.0.0-test.zip bundle.json)"
+DECLARED="$(sed -n 's/.*"fileCount": *\([0-9]*\).*/\1/p' <<<"$MANIFEST")"
+ACTUAL="$(grep -vc '/$' <<<"$ENTRIES")"
+if [ "$DECLARED" = "$ACTUAL" ]; then
+	report "bundle.json fileCount matches zip ($ACTUAL)" yes
+else
+	report "bundle.json fileCount matches zip" no "declared $DECLARED, zip holds $ACTUAL"
+fi
+
+for want in '"schema": 1' '"profile": "positron"' '"version": "0.0.0-test"'; do
+	if grep -qF "$want" <<<"$MANIFEST"; then
+		report "bundle.json has $want" yes
+	else
+		report "bundle.json has $want" no "$MANIFEST"
+	fi
+done
+
+# The rewrite must leave the index pointing inside the bundle.
+INDEX="$(unzip -p positron-llms-0.0.0-test.zip llms.txt)"
+if grep -qF '(databot.llms.md)' <<<"$INDEX" && ! grep -qF 'positron.posit.co' <<<"$INDEX"; then
+	report "llms.txt links are bundle-relative" yes
+else
+	report "llms.txt links are bundle-relative" no "$INDEX"
+fi
+
+if shasum -a 256 -c positron-llms-0.0.0-test.zip.sha256sum > /dev/null 2>&1; then
+	report "sidecar digest verifies" yes
+else
+	report "sidecar digest verifies" no ""
+fi
+
+new_site
+expect_ok "workbench profile builds" _site workbench 0.0.0-test
+if [ -f positron-workbench-llms-0.0.0-test.zip ]; then
+	report "workbench basename is positron-workbench-llms" yes
+else
+	report "workbench basename is positron-workbench-llms" no ""
+fi
+
+# Regression test for the guard that used to scan every staged file: docs may
+# carry absolute site links in prose, and that must not fail the build.
+new_site
+printf '# Databot\n\nWorks with [Positron](https://positron.posit.co/) and see\n[Packages](https://positron.posit.co/packages-pane).\n' \
+	> _site/databot.llms.md
+expect_ok "prose site link in a doc is allowed" _site positron 0.0.0-test
+
+new_site
+printf -- '- [Databot](https://positron.posit.co/databot.llms.md#usage)\n' >> _site/llms.txt
+expect_ok "link with a fragment resolves" _site positron 0.0.0-test
+
+new_site
+printf -- '- [Databot](https://positron.posit.co/databot.llms.md?v=2)\n' >> _site/llms.txt
+expect_ok "link with a query string resolves" _site positron 0.0.0-test
+
+echo
+echo "== rejected =="
+
+new_site
+rm _site/llms.txt
+expect_fail "missing llms.txt" "llms.txt not found" _site positron 0.0.0-test
+
+new_site
+find _site -name '*.llms.md' -delete
+expect_fail "no docs rendered" "no *.llms.md files" _site positron 0.0.0-test
+
+new_site
+rm _site/databot.llms.md
+expect_fail "index links a file not in the bundle" "which is not in the bundle" \
+	_site positron 0.0.0-test
+
+new_site
+printf -- '- [Root](/databot.llms.md)\n' >> _site/llms.txt
+expect_fail "root-relative link" "not bundle-relative" _site positron 0.0.0-test
+
+new_site
+printf -- '- [Contact](mailto:docs@posit.co)\n' >> _site/llms.txt
+expect_fail "mailto link" "not bundle-relative" _site positron 0.0.0-test
+
+# http:// survives a rewrite that only strips https://, so guard 3 is what fires.
+new_site
+printf -- '- [Databot](http://positron.posit.co/databot.llms.md)\n' >> _site/llms.txt
+expect_fail "site URL the rewrite missed" "still references positron.posit.co" \
+	_site positron 0.0.0-test
+
+new_site
+expect_fail "unknown profile" "profile must be" _site dailies 0.0.0-test
+
+echo
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
### Summary
Adds a `build-llms-bundle.sh` script that packages LLM-friendly `.llms.md` docs into a versioned zip bundle into our existing release-docs workflow.

### The flow
1. Render both Quarto profiles (unchanged)
2. **Build the LLM bundles**, once per profile
   - 2a. Copy `llms.txt` and the `*.llms.md` docs into a staging dir
   - 2b. Rewrite the site URLs in `llms.txt` to relative paths
   - 2c. Guards: no site URL left, all links relative, all targets exist, file count matches
   - 2d. Write `bundle.json`
   - 2e. Zip, then check the zip's contents against what was staged
   - 2f. Check the zip against the 1MB size budget
   - 2g. Write and verify the `.sha256sum`
3. Configure AWS credentials
4. Pre-flight: stop if this version is already published, unless `overwrite`
5. Build the full docs zips (unchanged)
6. Cut the GitHub release, marked prerelease unless the channel is `releases`
7. Upload the full docs zips (unchanged)
8. Upload the LLM zips and checksums, immutable, checksum first
9. Move the `latest` aliases, `releases` channel only
10. Assert: every object exists, right Cache-Control, aliases hold this release's bytes
11. Invalidate CloudFront (unchanged)

### QA Notes
I did as much local testing as I could - see [this PR comment](https://github.com/posit-dev/positron-website/pull/425#issuecomment-5122408082) below.

#### Actions to perform post-merge

<details>
<summary>Post-merge checklist</summary>

- [ ] **Staging run** to exercise the pipeline for real:
  - Run `workflow_dispatch` with:
    - `release_channel: staging`
    - `version: 0.0.0-llmstest`
    - `create_release: true`
  - Aliases are gated on `releases`, so staging covers build, upload, and assert without touching anything live.
  - (`create_release: false` routes to `gh release upload`, which fails on a tag that does not exist.)

- [ ] Delete the throwaway release and tag:

  ```bash
  gh release delete 0.0.0-llmstest --yes --cleanup-tag
  ```

- [ ] Pull the staging bundle back down and spot-check:
  - `shasum -a 256 -c` against its sidecar
  - `bundle.json` fields
  - Confirm the workbench bundle excludes:
    - `download`
    - `install`
    - `privacy`

- [ ] **Verify `Cache-Control` and conditional GET through the CDN** (commands below).
  - Cache headers are only verified at the S3 origin.
  - Moto cannot test CloudFront.
  - This is the one behavior not covered by automated tests.

- [ ] **First `releases` run**
  - Confirm the four alias objects exist.
  - Verify each alias digest matches its versioned ZIP.
  - The assert step now performs this verification, so a green run confirms success.

- [ ] **Consumer check**
  - `parseManifest()` accepts the bundle on a cold-cache Positron install.
  - Assistant reads documentation from disk without fetching from `positron.posit.co`.

- [ ] Record the rollback procedure.
  - Versioned objects are immutable.
  - Recovery consists of:
    - Repointing aliases to the previous version with `aws s3 cp`
    - Using `--cache-control no-cache`
    - Performing a CloudFront invalidation
  - Never overwrite a published versioned object.

### CDN checks

```bash
BASE=https://cdn.posit.co/positron

# Does CloudFront forward the Cache-Control we set at the origin?
curl -sI $BASE/staging/docs/positron-llms-0.0.0-llmstest.zip \
  | grep -i 'cache-control\|etag\|x-cache'

# no-cache is only worth setting if this returns 304
ETAG=$(curl -sI $BASE/releases/docs/positron-llms-latest.zip \
  | grep -i etag \
  | tr -d '\r' \
  | cut -d' ' -f2)

curl -sI -H "If-None-Match: $ETAG" \
  $BASE/releases/docs/positron-llms-latest.zip \
  | head -1
```

</details>