### PR TITLE
Clarify out-of-the-box support (R, Python) plus extensions

### DIFF
--- a/managing-interpreters.qmd
+++ b/managing-interpreters.qmd
@@ -3,7 +3,11 @@ title: "Managing Interpreters"
 description: "Manage multiple Python and R interpreter sessions in Positron. Switch between environments, configure startup options, and run multiple sessions simultaneously."
 ---
 
-Positron is designed to support multiple R and Python interpreter sessions. This enables workflows that span multiple environments, and allows you to switch between them easily within a single workspace.
+Positron is designed to support multiple interpreter sessions. This enables workflows that span multiple environments, and allows you to switch between them easily within a single workspace.
+
+::: {.callout-note}
+Positron comes with full support for Python and R interpreters out of the box. You can extend Positron to support other types of interpreters by installing extensions that provide such functionality, such as the extensions for [Julia](https://github.com/TidierOrg/positron-julia) or [ggsql](https://ggsql.org/). Read more about [extensions in Positron](extensions.qmd).
+:::
 
 Positron has two types of interpreter sessions:
 

--- a/managing-interpreters.qmd
+++ b/managing-interpreters.qmd
@@ -3,11 +3,9 @@ title: "Managing Interpreters"
 description: "Manage multiple Python and R interpreter sessions in Positron. Switch between environments, configure startup options, and run multiple sessions simultaneously."
 ---
 
-Positron is designed to support multiple interpreter sessions. This enables workflows that span multiple environments, and allows you to switch between them easily within a single workspace.
+Positron is designed to support multiple interpreter sessions. This enables workflows that span multiple environments, and allows you to switch between them easily within a single workspace. 
 
-::: {.callout-note}
 Positron comes with full support for Python and R interpreters out of the box. You can extend Positron to support other types of interpreters by installing extensions that provide such functionality, such as the extensions for [Julia](https://github.com/TidierOrg/positron-julia) or [ggsql](https://ggsql.org/). Read more about [extensions in Positron](extensions.qmd).
-:::
 
 Positron has two types of interpreter sessions:
 


### PR DESCRIPTION
This PR updates the page at <https://positron.posit.co/managing-interpreters.html> to clarify that Positron:

- comes with full support for Python and R out of the box
- can be extended to support other language interpreters with extensions

I used two examples here, the Julia extensions plus ggsql.

Related to https://github.com/posit-dev/positron/issues/3679