### PR TITLE
Remove three unused videos from Git LFS

### DIFF
--- a/videos/notebook-data-explorer-variables.mp4
+++ b/videos/notebook-data-explorer-variables.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:18406fa85e0e34e307d2e6427b9bdb199ac9a0ff62849d318feb3e59722b79f7
-size 5769835

--- a/videos/notebook-help.mp4
+++ b/videos/notebook-help.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f1b61ebdf5b2889acec34f8da9a47c2f74537129750f378d13caa74f200a478
-size 3887073

--- a/videos/notebook-publish-connect.mp4
+++ b/videos/notebook-publish-connect.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b2d55f4003c57b74cd422dff89afc99abaa19bc0655539a77228acc8e90cf71
-size 12333808


### PR DESCRIPTION
When we had our blog here in this repo, we also kept the assets for those here as well. The post in `blog/posts/2026-03-12-notebooks-march-announcement/index.qmd` was the only thing referencing these videos, and it was deleted in 2e86483 when the blog moved to opensource.posit.co. That commit removed the post's own images but left these behind, since they live in `videos/` rather than in the post directory.

  - videos/notebook-publish-connect.mp4: 12.0 MB
  - videos/notebook-data-explorer-variables.mp4: 5.8 MB
  - videos/notebook-help.mp4: 3.9 MB

That is 21.7 MB no longer fetched by fresh clones or by CI checkouts that set `lfs: true`. The `videos/` directory goes from 21 files to 18, which now matches the 18 `{{< video >}}` calls in the docs exactly.

Note that this does not purge the objects from LFS history, so the repository's LFS storage usage is unchanged.
