### PR TITLE
Document console.historyApiEnabled privacy setting

### DIFF
--- a/managing-interpreters.qmd
+++ b/managing-interpreters.qmd
@@ -134,6 +134,12 @@ When a console session reports an error, you can send it to Posit Assistant for 
 
 To disable Console Fix and Explain, set [`console.assistantActions.enabled`](positron://settings/console.assistantActions.enabled) to `false`. See [Configure AI features](ai-configuration.qmd) for other ways to turn AI features on and off.
 
+### Control what extensions read from the console
+
+Extensions such as Posit Assistant can read your recent console history — the commands you've run, with their output and any errors — to offer more relevant help without re-running code.
+
+To stop extensions from reading console history, set [`console.historyApiEnabled`](positron://settings/console.historyApiEnabled) to `false`.
+
 ## Notebook sessions
 
 Notebook sessions run the code from a Jupyter Notebook's cells and are tied to the notebook file. To manage a notebook session, use the Kernel Selector and the restart icon in the notebook editor's action bar. Closing the notebook shuts down its session.

--- a/managing-interpreters.qmd
+++ b/managing-interpreters.qmd
@@ -136,7 +136,7 @@ To disable Console Fix and Explain, set [`console.assistantActions.enabled`](pos
 
 ### Control what extensions read from the console
 
-Extensions such as Posit Assistant can read your recent console history — the commands you've run, with their output and any errors — to offer more relevant help without re-running code.
+Extensions such as Posit Assistant can read your recent console history to offer more relevant help without re-running code. This history includes the commands you have run, along with their output and any errors.
 
 To stop extensions from reading console history, set [`console.historyApiEnabled`](positron://settings/console.historyApiEnabled) to `false`.
 


### PR DESCRIPTION
## Summary

Documents the new `console.historyApiEnabled` privacy setting introduced in [posit-dev/positron#15207](https://github.com/posit-dev/positron/pull/15207).

That PR adds a read-only `positron.runtime.getConsoleHistory` extension method (primarily consumed by Posit Assistant, documented in the Assistant repo) and a user-facing `console.historyApiEnabled` setting (default `true`) that lets users stop extensions from reading their console history.

This change adds a short, user-facing subsection under **Console sessions** in `managing-interpreters.qmd`, alongside the existing `console.assistantActions.enabled` coverage and following the same pattern. It documents only the setting — not the extension method — and avoids developer jargon.

## Rendered content

> ### Control what extensions read from the console
>
> Extensions such as Posit Assistant can read your recent console history to offer more relevant help without re-running code. This history includes the commands you have run, along with their output and any errors.
>
> To stop extensions from reading console history, set `console.historyApiEnabled` to `false`.

## Testing

- `quarto render managing-interpreters.qmd` succeeds; the new subsection and the `positron://settings/console.historyApiEnabled` link render correctly.
- Reviewed against the Posit style guide (doc-reviewer rules): no remaining violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)