### PR TITLE
Link to Academy learning path from `/tutorials`

### DIFF
--- a/tutorials.qmd
+++ b/tutorials.qmd
@@ -30,6 +30,10 @@ listing:
 
 Learn how to get the most out of Positron.
 
+::: {.callout-note}
+Looking for a more guided learning experience? Check out the [Introduction to Positron](https://academy.posit.co/path/introduction-to-positron) path on Posit Academy.
+:::
+
 ::: {#tutorials}
 :::
 


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/15273

This PR adds a little callout to point folks to the new learning path at Posit Academy:

<img width="975" height="526" alt="Screenshot 2026-08-03 at 9 32 18 AM" src="https://github.com/user-attachments/assets/c7c0591e-4b94-41b4-917b-f00f3f8df282" />

