### PR TITLE
Reorganize menu links and navigation items in top bar

### DIFF
--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -54,17 +54,21 @@ website:
         href: about.qmd
       - text: "Resources"
         menu:
+          - text: "Blog"
+            icon: journal-text
+            href: https://opensource.posit.co/blog/q/positron/
+            target: _blank
           - text: "Sign up for updates"
             href: https://posit.co/positron-updates-signup/
             target: _blank
             icon: envelope
-          - text: "Positron at Posit Open Source"
-            icon: code-slash
-            href: https://opensource.posit.co/blog/q/positron/
-            target: _blank  
-          - text: "Company Blog Posts"
-            icon: box-arrow-up-right
-            href: https://posit.co/blog/?post_tag=positron  
+          - text: "LinkedIn"
+            icon: linkedin
+            href: https://www.linkedin.com/showcase/positron-ide/
+            target: _blank
+          - text: "Positron on posit.co"
+            icon: laptop
+            href: https://posit.co/products/ide/positron
             target: _blank
           - text: "Events"
             icon: calendar-event

--- a/_quarto-positron.yml
+++ b/_quarto-positron.yml
@@ -66,15 +66,15 @@ website:
             icon: linkedin
             href: https://www.linkedin.com/showcase/positron-ide/
             target: _blank
-          - text: "Positron on posit.co"
-            icon: laptop
-            href: https://posit.co/products/ide/positron
-            target: _blank
           - text: "Events"
             icon: calendar-event
             href: https://posit.co/events/?search=positron&poststatus=all
             target: _blank
-      
+          - text: "More Posit products"
+            icon: laptop
+            href: https://posit.co/products/
+            target: _blank
+
     right:
       - text: "<span id='top-bar-download-btn' class='btn btn-primary'>Download</span>"
         href: download.qmd

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -75,13 +75,13 @@ website:
             icon: linkedin
             href: https://www.linkedin.com/showcase/positron-ide/
             target: _blank
-          - text: "Positron on posit.co"
-            icon: laptop
-            href: https://posit.co/products/ide/positron
-            target: _blank
           - text: "Events"
             icon: calendar-event
             href: https://posit.co/events/?search=positron&poststatus=all
+            target: _blank
+          - text: "More Posit products"
+            icon: laptop
+            href: https://posit.co/products/
             target: _blank
       
     right:

--- a/_quarto-workbench.yml
+++ b/_quarto-workbench.yml
@@ -63,17 +63,21 @@ website:
         href: about.qmd
       - text: "Resources"
         menu:
+          - text: "Blog"
+            icon: journal-text
+            href: https://opensource.posit.co/blog/q/positron/
+            target: _blank
           - text: "Sign up for updates"
             href: https://posit.co/positron-updates-signup/
             target: _blank
             icon: envelope
-          - text: "Positron at Posit Open Source"
-            icon: code-slash
-            href: https://opensource.posit.co/blog/q/positron/
-            target: _blank  
-          - text: "Company Blog Posts"
-            icon: box-arrow-up-right
-            href: https://posit.co/blog/?post_tag=positron  
+          - text: "LinkedIn"
+            icon: linkedin
+            href: https://www.linkedin.com/showcase/positron-ide/
+            target: _blank
+          - text: "Positron on posit.co"
+            icon: laptop
+            href: https://posit.co/products/ide/positron
             target: _blank
           - text: "Events"
             icon: calendar-event


### PR DESCRIPTION
Fixes https://github.com/posit-dev/positron/issues/15216

This PR makes some updates to the "Resources" dropdown here:

<img width="609" height="284" alt="Screenshot 2026-08-06 at 12 19 53 PM" src="https://github.com/user-attachments/assets/bf0c813e-e746-4fcd-b2f6-971e6ce5ce79" />

We don't want the blog to be a top level item in the top nav here (for consistency and just running out of space) but I put it first.